### PR TITLE
added error page form and routes to it if an api return (response.err…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Added error page form and routes to it if an api return (response.error.code) not 200
 <!-- Unreleased changes can be added here. -->
 
 ## 1.0.19

--- a/app/src/js/App.js
+++ b/app/src/js/App.js
@@ -10,7 +10,7 @@ import { library, dom } from '@fortawesome/fontawesome-svg-core';
 import { faSignOutAlt, faSearch, faSync, faRedo, faPlus, faInfoCircle, faTimesCircle, faSave, faCalendar, faExpand, faCompress, faClock, faCaretDown, faChevronDown, faSort, faSortDown, faSortUp, faArrowAltCircleLeft, faArrowAltCircleRight, faArrowAltCircleDown, faArrowAltCircleUp, faArrowRight, faCopy, faEdit, faArchive, faLaptopCode, faServer, faHdd, faExternalLinkSquareAlt, faToggleOn, faToggleOff, faExclamationTriangle, faCoins, faCheckCircle, faCircle } from '@fortawesome/free-solid-svg-icons';
 
 // Authorization & Error Handling
-// import ErrorBoundary from './components/Errors/ErrorBoundary';
+import Error from './components/error';
 import NotFound from './components/404';
 import Auth from './components/Auth';
 
@@ -44,6 +44,7 @@ const MainRoutes = () => {
     <Main path='/'>
       <Switch>
         <Route exact path='/' component={Home} />
+        <Route path='/error' component={Error} />
         <Route path='/404' component={NotFound} />
         <Route path='/requests' component={Requests} />
         <Route path='/forms' component={Forms} />
@@ -58,7 +59,7 @@ const MainRoutes = () => {
         <Route path='/modules' component={Modules} />
         <Route path='/upload' component={Upload} />
         <Route path='/test-api' component={TestApi} />
-        <Route component={NotFound} />
+        <Route component={Error} />
       </Switch>
     </Main>
   );

--- a/app/src/js/actions/helpers.js
+++ b/app/src/js/actions/helpers.js
@@ -9,13 +9,13 @@ export const formatError = (response = {}, body) => {
   body = body || {};
   if (body.name) error = body.name;
   if (body.message) error += `${(error ? ': ' : '')}${body.message}`;
+  if (response && response.error && response.error.message) error += `${(error ? ': ' : '')}${response.error.message}`;
   return error;
 };
 
 export const getErrorMessage = (response) => {
   const { body } = response;
-  const errorMessage = (body && body.errorMessage) || (body && body.message) || (body && body.detail);
-
+  const errorMessage = (body && body.errorMessage) || (body && body.message) || (body && body.detail) || (response && response.error && response.error.message);
   if (errorMessage) return errorMessage;
   return formatError(response, body);
 };

--- a/app/src/js/components/error.js
+++ b/app/src/js/components/error.js
@@ -1,0 +1,36 @@
+'use strict';
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import { withRouter } from 'react-router-dom';
+
+class Error extends React.Component {
+  constructor (props) {
+    super(props);
+    this.state = {
+      code: '',
+      error: ''
+    };
+  }
+
+  componentDidMount () {
+    const { code, error } = this.props.router.location.query;
+    this.setState({ code, error: decodeURIComponent(decodeURIComponent(error)) });
+  }
+
+  render () {
+    return (
+      <div className='page__404' style={{ textAlign: 'center' }}>
+        <h1 style={{ fontSize: '10em', marginBottom: '0' }}>Error</h1>
+        <p style={{ fontSize: '5em' }}> {this.state.error}</p>
+      </div>
+    );
+  }
+}
+
+Error.propTypes = {
+  match: PropTypes.object,
+  router: PropTypes.object
+};
+
+export default withRouter(connect(state => state)(Error));

--- a/app/src/js/middleware/request.js
+++ b/app/src/js/middleware/request.js
@@ -9,6 +9,7 @@ import {
 } from '../actions/helpers';
 import log from '../utils/log';
 import { isValidApiRequestAction } from './validate';
+import Error from '../components/error';
 
 const handleError = ({ id, type, error, requestAction }, next) => {
   console.groupCollapsed('handleError');
@@ -70,8 +71,18 @@ export const requestMiddleware = ({ dispatch, getState }) => next => action => {
     const start = new Date();
     return requestPromise(requestAction)
       .then((response) => {
+        const errorCode = response?.error?.code || 200
+        if(errorCode !== 200){
+            const error = new Error(getErrorMessage(response));
+            const errorType = type + '_ERROR';
+            log((id ? errorType + ': ' + id : errorType));
+            log(error);
+            const redirectUrl = new URL(`${window.location.origin}/error`);
+            redirectUrl.searchParams.set('code', errorCode);
+            redirectUrl.searchParams.set('error', encodeURIComponent(getErrorMessage(response)));
+            window.location.href=redirectUrl
+        }
         const { body } = response;
-
         if (+response.statusCode >= 400) {
           const error = new Error(getErrorMessage(response));
           return handleError({ id, type, error, requestAction }, next);
@@ -83,6 +94,5 @@ export const requestMiddleware = ({ dispatch, getState }) => next => action => {
       })
       .catch((error) => handleError({ id, type, error, requestAction }, next));
   }
-
   return next(action);
 };

--- a/app/src/js/middleware/request.js
+++ b/app/src/js/middleware/request.js
@@ -73,10 +73,6 @@ export const requestMiddleware = ({ dispatch, getState }) => next => action => {
       .then((response) => {
         const errorCode = response?.error?.code || 200
         if(errorCode !== 200){
-            const error = new Error(getErrorMessage(response));
-            const errorType = type + '_ERROR';
-            log((id ? errorType + ': ' + id : errorType));
-            log(error);
             const redirectUrl = new URL(`${window.location.origin}/error`);
             redirectUrl.searchParams.set('code', errorCode);
             redirectUrl.searchParams.set('error', encodeURIComponent(getErrorMessage(response)));


### PR DESCRIPTION
Added error page form and routes to it if an api return (response.error.code) not 200

# Description

Added error page form and routes to it if an api return (response.error.code) not 200

## Spec

Designs: Was advised by @camposeddie to re-use 404 form for error form.

See Ticket: EDPUB-533

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull branch locally.
3. From overview repo run 'npm run start-dev' (Make sure dashboard re-builds)
4. Log into the dashboard as 'Earthdata Pub System' before the next step.
5. In the code, open app/src/js/middleware/reqruest.js.
6. In the requestMiddleware function, copy paste the below fake api response right before the errorCode variable is set (line 74):
```
response = {
            "success": false,
            "body": {},
            "error": {
              "code": 503, 
              "message": "An error occurred!"
            }
        }
```
7. Once the code is saved with that fake response, navigate the dashboard and verify you are routed to a generic error page with the above message being displayed.

## Change Log

- [X] Added error page form and routes to it if an api return (response.error.code) not 200 (f45f3ba91f8ff97f276f0c547a81d031a93fbefc)