### PR TITLE
EDPUB-804 Investigate and fixing the local timezone on updatedtime

### DIFF
--- a/app/src/js/utils/format.js
+++ b/app/src/js/utils/format.js
@@ -91,7 +91,8 @@ export const lastUpdated = function (datestring, text) {
   const meta = text || 'Last Updated';
   let day, time;
   if (datestring) {
-    const date = moment(datestring);
+    const date = moment.utc(datestring); // Parse the date as UTC
+    const localDate = date.local(); // Convert to local time zone
     day = date.format('MMM. D, YYYY');
     time = date.format('h:mm a');
   }


### PR DESCRIPTION
# Description

Investigate the possibility of displaying local (to the user) time

## Spec

See Ticket: [EDPUB-804](https://bugs.earthdata.nasa.gov/browse/EDPUB-804)

---

## Validation

1. Click on the Conversations tab
2. Click on All filter
3. Type your reply and check the timestamp of when the message was submitted. This should be of the local time.


---

## Change Log
Made changes to one file app/src/js/utils/format.js