### PR TITLE
removed funny line from dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- Removed funny line from dropdown
 - Added error page form and routes to it if an api return (response.error.code) not 200
 <!-- Unreleased changes can be added here. -->
 

--- a/app/src/css/_base.scss
+++ b/app/src/css/_base.scss
@@ -1028,6 +1028,7 @@ textarea {
 }
 div.selectButton {
   padding: 0;
+  z-index: 10;
 }
 div#producerSelect.selectButton {
   width: inherit;


### PR DESCRIPTION
# Description

Removed funny line from dropdown

## Spec

See Ticket: EDPUB-1179

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Push out to sit
3. Verify data producer drop-down does not have any grey lines in it.  See issue screenshot for eg.

## Change Log

* [removed funny line from dropdown](b31adac252ccb52d3a10fc16d906ae81d5775e08)