### PR TITLE
EDPUB:1137: Make graphical workflow the default display

### DIFF
--- a/app/src/js/components/Workflows/workflow.js
+++ b/app/src/js/components/Workflows/workflow.js
@@ -22,7 +22,7 @@ function onLoad (reactFlowInstance) {
 class Workflows extends React.Component {
   constructor () {
     super();
-    this.state = { view: 'json', nodes: [], edges: [], renderedGraph: false };
+    this.state = { view: 'graph', nodes: [], edges: [], renderedGraph: false };
     this.renderReadOnlyJson = this.renderReadOnlyJson.bind(this);
     this.renderJson = this.renderJson.bind(this);
     this.showGraph = this.showGraph.bind(this);
@@ -146,10 +146,10 @@ class Workflows extends React.Component {
               : record.data
                 ? <div>
                   <div className='tab--wrapper'>
-                    <button className={'button--tab ' + (this.state.view === 'json' ? 'button--active' : '')}
-                      onClick={() => this.state.view !== 'json' && this.setState({ view: 'json' })}>JSON View</button>
                     <button className={'button--tab ' + (this.state.view === 'graph' ? 'button--active' : '')}
                       onClick={() => this.state.view !== 'graph' && this.setState({ view: 'graph' })}>Graphical View</button>
+                    <button className={'button--tab ' + (this.state.view === 'json' ? 'button--active' : '')}
+                      onClick={() => this.state.view !== 'json' && this.setState({ view: 'json' })}>JSON View</button>
                   </div>
                   <div>
                     {this.state.view === 'graph' ? this.showGraph(record.data) : this.renderJson(record.data)}


### PR DESCRIPTION
# Description
Make graphical workflow the default display
To provide a better UI/UX the graphical view should be the default view and the JSON view should be the second choice/link

## Spec
See Ticket: [EDPUB-1137](https://bugs.earthdata.nasa.gov/browse/EDPUB-1137)

---

## Validation

1. Click on workflow navigator
2. Click on one of the workflows
3. By default we see a graphical view