### PR TITLE
EDPUB-1224: Update dashboard action to call metadata mapping endpoint for export

### DIFF
--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -379,6 +379,15 @@ export const restoreRequest = (requestId) => ({
   }
 });
 
+export const metadataMapper = (requestId) => ({
+  [CALL_API]: {
+    type: types.REQUEST_RESTORE,
+    method: 'POST',
+    path: 'data/submission/operation/mapMetadata',
+    body: { id: requestId }
+  }
+});
+
 export const addUserToRequest = (payload) => ({
   [CALL_API]: {
     type: types.REQUEST_ADDUSER,

--- a/app/src/js/components/Requests/request.js
+++ b/app/src/js/components/Requests/request.js
@@ -10,7 +10,8 @@ import {
   addUserToRequest,
   removeUserFromRequest,
   setWorkflowStep,
-  copyRequest
+  copyRequest,
+  metadataMapper
 } from '../../actions';
 import { get } from 'object-path';
 import {
@@ -184,7 +185,9 @@ class RequestOverview extends React.Component {
   }
 
   async exportMetadata() {
-    const mappedData = JSON.stringify(this.props.requests.detail.data.metadata, null, 2);
+    const { requestId } = this.props.match.params;
+    const updatedMetadata = await this.props.dispatch(metadataMapper(requestId)); 
+    const mappedData = updatedMetadata.data ? JSON.stringify(updatedMetadata.data): "";
     const a = document.createElement('a');
     const file = new Blob([mappedData], { type: 'application/json' });
     a.href = URL.createObjectURL(file);

--- a/app/src/js/components/Workflows/workflow.js
+++ b/app/src/js/components/Workflows/workflow.js
@@ -22,7 +22,7 @@ function onLoad (reactFlowInstance) {
 class Workflows extends React.Component {
   constructor () {
     super();
-    this.state = { view: 'json', nodes: [], edges: [], renderedGraph: false };
+    this.state = { view: 'graph', nodes: [], edges: [], renderedGraph: false };
     this.renderReadOnlyJson = this.renderReadOnlyJson.bind(this);
     this.renderJson = this.renderJson.bind(this);
     this.showGraph = this.showGraph.bind(this);
@@ -146,10 +146,10 @@ class Workflows extends React.Component {
               : record.data
                 ? <div>
                   <div className='tab--wrapper'>
-                    <button className={'button--tab ' + (this.state.view === 'json' ? 'button--active' : '')}
-                      onClick={() => this.state.view !== 'json' && this.setState({ view: 'json' })}>JSON View</button>
                     <button className={'button--tab ' + (this.state.view === 'graph' ? 'button--active' : '')}
                       onClick={() => this.state.view !== 'graph' && this.setState({ view: 'graph' })}>Graphical View</button>
+                    <button className={'button--tab ' + (this.state.view === 'json' ? 'button--active' : '')}
+                      onClick={() => this.state.view !== 'json' && this.setState({ view: 'json' })}>JSON View</button>
                   </div>
                   <div>
                     {this.state.view === 'graph' ? this.showGraph(record.data) : this.renderJson(record.data)}


### PR DESCRIPTION
# Description

Update dashboard action to call metadata mapping endpoint for export

## Spec

Designs: Currently, the dashboard action associated with exporting metadata relies on the mapped metadata to already exist as a part of the request details. An additional dynamic metadata mapping endpoint has been added to the API so that the precondition of mapping is no longer required. This task aims to update the export metadata dashboard action to call the API metadata mapping endpoint then use the response to populate and download a JSON file.

See Ticket: [EDPUB-1224](https://bugs.earthdata.nasa.gov/browse/EDPUB-1224)

---

## Validation

1. Click on requests
2. Click on the Data Product name that already have a form filled up
3. Click on the settings icon on the top left of the page, then click export on the options. 
