### PR TITLE
feature: granular review step privileges

### DIFF
--- a/app/src/js/components/Comments/comments.js
+++ b/app/src/js/components/Comments/comments.js
@@ -100,7 +100,6 @@ class Comment extends React.Component {
 
   render() {
     let reviewable = false;
-    let { canReview } = requestPrivileges(this.props.privileges);
     let sameFormAsStep = false;
     const search = this.props.location.search.split('=');
     let requestId = '';
@@ -109,6 +108,7 @@ class Comment extends React.Component {
     }
     let step = search[2];
     let stepName = this.getFormalName(step);
+    let { canReview } = requestPrivileges(this.props.privileges, step);
     let request = '';
     let conversationId = '';
     let requestName = '';

--- a/app/src/js/components/Forms/form.js
+++ b/app/src/js/components/Forms/form.js
@@ -382,7 +382,8 @@ class FormOverview extends React.Component {
     let editable = false;
     let reviewable = false;
     const { canEdit } = formPrivileges(this.props.privileges);
-    let { canReview } = requestPrivileges(this.props.privileges);
+    const search = new URLSearchParams(this.props.location.search);
+    let { canReview } = requestPrivileges(this.props.privileges, search.get('step'));
     let sameFormAsStep = false;
     let requestId = this.props.location.search.split('=')[1];
     const formId = this.props.match.params.formId;

--- a/app/src/js/components/Requests/approval.js
+++ b/app/src/js/components/Requests/approval.js
@@ -88,11 +88,11 @@ class ApprovalStep extends React.Component {
   }
 
   render() {
-    let { canReview } = requestPrivileges(this.props.privileges);
     const search = this.props.location.search.split('=');
     const requestId = search[1].replace(/&step/g, '');
     const step = search[2];
     const stepName = this.getFormalName(step);
+    let { canReview } = requestPrivileges(this.props.privileges, step);
     let requestForms = [];
     let showTable = false;
     let reviewReady = false;

--- a/app/src/js/components/Review/review.js
+++ b/app/src/js/components/Review/review.js
@@ -68,8 +68,10 @@ class ReviewStep extends React.Component {
   }
 
   render() {
-    const { canReview } = requestPrivileges(this.props.privileges);
-    const requestId = this.props.location.search.split('=')[1];
+    const search = this.props.location.search.split('=');
+    const requestId = search[1].replace(/&step/g, '');
+    const step = search[2];
+    let { canReview } = requestPrivileges(this.props.privileges, step);
     let reviewable = false;
     let reviewReady = false;
     if (this.hasStepData()) {

--- a/app/src/js/reducers/api.js
+++ b/app/src/js/reducers/api.js
@@ -24,7 +24,11 @@ function getExpiration (token) {
 
 function reducePrivileges (user) {
   const privileges = user.user_privileges.reduce((acc, privilege) => {
-    const [entity, action] = privilege.split('_');
+    // Split the privilege into entity and action by the first underscore
+    // ex. REQUEST_REVIEW -> ['REQUEST', 'REVIEW']
+    // ex. REQUEST_REVIEW_MANAGER -> ['REQUEST', 'REVIEW_MANAGER']
+    const [entity, action] = privilege.split(/_(.+)/);
+
     if (!acc[entity]) {
       acc[entity] = [action || '-'];
     } else {
@@ -32,6 +36,7 @@ function reducePrivileges (user) {
     }
     return acc;
   }, {});
+
   return privileges;
 }
 

--- a/app/src/js/utils/privileges.js
+++ b/app/src/js/utils/privileges.js
@@ -85,7 +85,7 @@ export const groupPrivileges = (privileges) => {
   };
 };
 
-export const requestPrivileges = (privileges) => {
+export const requestPrivileges = (privileges, stepName) => {
   if (privileges.ADMIN) {
     return {
       canRead: true,
@@ -110,7 +110,7 @@ export const requestPrivileges = (privileges) => {
       canResume: privileges.REQUEST.includes('RESUME'),
       canSubmit: privileges.REQUEST.includes('SUBMIT'),
       canApply: privileges.REQUEST.includes('APPLY'),
-      canReview: privileges.REQUEST.includes('REVIEW'),
+      canReview: requestCanReview(privileges, stepName),
       canReassign: privileges.REQUEST.includes('REASSIGN'),
       canLock: privileges.REQUEST.includes('LOCK'),
       canUnlock: privileges.REQUEST.includes('UNLOCK'),
@@ -138,6 +138,20 @@ export const requestPrivileges = (privileges) => {
     canRemoveUser: false
   };
 };
+
+/**
+ * Determines if the user has privileges to review the request.
+ * Allows for more granular privilege checking based on the step name.
+ */
+export const requestCanReview = (privileges, stepName) => {
+  console.log('request can review ', privileges, stepName)
+
+  if (stepName && stepName.match(/management_review/g)) {
+    return privileges.REQUEST.includes("REVIEW_MANAGER");
+  }
+
+  return privileges.REQUEST.includes("REVIEW");
+}
 
 export const formPrivileges = (privileges) => {
   if (privileges.ADMIN) {

--- a/app/src/js/utils/privileges.js
+++ b/app/src/js/utils/privileges.js
@@ -193,3 +193,19 @@ export const questionPrivileges = (privileges) => {
     canDelete: false
   };
 };
+
+/**
+ * given an array of privileges (strings), return an object with keys as the type of privilege and values as an array of actions
+ * 
+ * @example given an array of privileges ['USER_READ', 'USER_CREATE', 'GROUP_READ', 'GROUP_CREATE'], will return { USER: ['READ', 'CREATE'], GROUP: ['READ', 'CREATE'] }
+ */
+export const getPrivilegesByType = (privileges) => {
+    return privileges.reduce((acc, privilege) => {
+        const [type, action] = privilege.split(/_(.+)/);
+        if (!acc[type]) {
+            acc[type] = [];
+        }
+        acc[type].push(action);
+        return acc;
+    }, {});
+}

--- a/app/src/js/utils/privileges.js
+++ b/app/src/js/utils/privileges.js
@@ -144,8 +144,6 @@ export const requestPrivileges = (privileges, stepName) => {
  * Allows for more granular privilege checking based on the step name.
  */
 export const requestCanReview = (privileges, stepName) => {
-  console.log('request can review ', privileges, stepName)
-
   if (stepName && stepName.match(/management_review/g)) {
     return privileges.REQUEST.includes("REVIEW_MANAGER");
   }

--- a/app/src/js/utils/table-config/requests.js
+++ b/app/src/js/utils/table-config/requests.js
@@ -15,12 +15,15 @@ import ErrorReport from '../../components/Errors/report';
 import Dropdown from '../../components/DropDown/simple-dropdown';
 import _config from '../../config';
 import { trigger } from '../../actions/events';
+import { getPrivilegesByType, requestPrivileges } from '../privileges';
 
-export const getPrivileges = () => {
+export const getPrivileges = (step) => {
   const user = JSON.parse(window.localStorage.getItem('auth-user'));
   if (user != null) {
     const roles = user.user_roles;
     const privileges = user.user_privileges;
+    const privilegesByType = getPrivilegesByType(privileges, step);
+
     const allPrivs = {
       isManager: privileges.find(o => o.match(/ADMIN/g))
         ? privileges.find(o => o.match(/ADMIN/g))
@@ -32,18 +35,13 @@ export const getPrivileges = () => {
       isStaff: privileges.find(o => o.match(/ADMIN/g))
         ? privileges.find(o => o.match(/ADMIN/g))
         : roles.find(o => o.short_name.match(/staff/g)),
-      canReview: privileges.find(o => o.match(/ADMIN/g))
-        ? privileges.find(o => o.match(/ADMIN/g))
-        : privileges.find(o => o.match(/REQUEST_REVIEW/g)),
-      canReassign: privileges.find(o => o.match(/ADMIN/g))
-        ? privileges.find(o => o.match(/ADMIN/g))
-        : privileges.find(o => o.match(/REQUEST_REASSIGN/g)),
       canCreateForm: privileges.find(o => o.match(/ADMIN/g))
         ? privileges.find(o => o.match(/ADMIN/g))
         : privileges.find(o => o.match(/FORM_CREATE/g)),
       canUpdateForm: privileges.find(o => o.match(/ADMIN/g))
         ? privileges.find(o => o.match(/ADMIN/g))
-        : privileges.find(o => o.match(/FORM_UPDATE/g))
+        : privileges.find(o => o.match(/FORM_UPDATE/g)),
+      ...requestPrivileges(privilegesByType, step),
     };
     return allPrivs;
   }
@@ -108,7 +106,7 @@ export const assignWorkflow = (request, formalName) => {
 };
 
 export const existingLink = (row, formId, formalName, step, stepType) => {
-  const allPrivs = getPrivileges();
+  const allPrivs = getPrivileges(step);
   let disabled = false;
   if (typeof allPrivs !== 'undefined' && allPrivs.canReview) {
     disabled = false;


### PR DESCRIPTION
# Description

An approach for adding granular privileges by step name. Please let me know your thoughts or if there are any changes needed.

This is a PR to support the GES DISC workflow, specifically to add a "Manager Approval Step" that no other role has access to. The existing functionality supported a "REVIEW" privilege, but any role with that privilege could review. GES DISC requested this to be restricted a bit more.

The change supports passing the current step name to "requestPrivileges", which allows for a bit of logic when returning whether a user can review or not.

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/GESDISC-246

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.

---

## Change Log

_(copy/paste-able change log notes. check the box when the change is also in CHANGELOG.md)_

* [Add _____](link to commitid)
* [Fix _____](link to commitid)