### PR TITLE
Updating messaging to be generic in case of a failed promise

### DIFF
--- a/app/src/js/middleware/request.js
+++ b/app/src/js/middleware/request.js
@@ -45,7 +45,7 @@ const handleError = ({ id, type, error, requestAction }, next) => {
     id,
     config: requestAction,
     type: errorType,
-    error: error.message
+    error: 'An internal error occurred. If the error continues, reach out to the EDPub development team.'
   });
 };
 


### PR DESCRIPTION
# Description

Updates the error message to be more generic as errors caught here shouldn't be anything fixable by a user. 


## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-480

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Deploy stack locally
4. Log in to the system
5. Once on the main dashboard, turn off the API docker containers
6. Attempt to create a new request and you should see the new more generic error message at the top of the dashboard

---
