### PR TITLE
EDPUB-1246: Fix Special Characters in Notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+- Updated conversations text formatting to accommodate special characters
 - Fixed zindex on user creation page.
 - Removed funny line from dropdown
 - Added error page form and routes to it if an api return (response.error.code) not 200

--- a/app/src/js/components/Conversations/conversation.js
+++ b/app/src/js/components/Conversations/conversation.js
@@ -17,11 +17,7 @@ import LoadingOverlay from '../LoadingIndicator/loading-overlay';
 const textRef = React.createRef();
 
 const reply = (dispatch, id) => {
-  const resp = textRef.current.value
-    .replace(/\n/g, "\\n")
-    .replace(/\t/g, '\\t')
-    .replace(/\r/g, '\\r')
-    .replace(/\"/g, '\\"');
+  const resp = encodeURI(textRef.current.value);
   const payload = { conversation_id: id, text: resp };
     dispatch(replyConversation(payload));
   textRef.current.value = '';
@@ -140,7 +136,7 @@ const Conversation = ({ dispatch, conversation, privileges, match }) => {
                 {
                   notes.map((note, key) => {
                     return (<Note note={note} key={key} />);
-                  }).reverse()
+                  })
                 }
               </div>
             </section>
@@ -187,7 +183,7 @@ const Note = ({ note }) => {
         <h3>{ note.from.name }</h3>
         {lastUpdated(note.sent, 'Sent')}
       </div>
-      <div className='flex__item--grow-1-wrap'>{ note.text }</div>
+      <div className='flex__item--grow-1-wrap'style={{whiteSpace: "pre"}}>{ decodeURI(note.text) }</div>
     </div>
   );
 };


### PR DESCRIPTION
# Description

Display special characters (especially `\n`, `\t`, \r`, etc. correctly in the dashboard conversations. Also removed note reversal to avoid confusion with enterprise standards.

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1246

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Deploy this branch and the API branch `EDPUB-1246-fix-special-char-issues` to SIT
3. Create a new request (no need to continue beyond selecting DAAC form.
4. Sign into another user account (to ensure you receive the email notification).
5. Navigate to the request conversation.
6. Send a message with the following text copy/pasted:
```
Test
	multiline	multitab
	with special's			 characters?
	and \n text? <---
```
7. Validate that the message is displayed as expected within the dashboard and within the email notification.
8. Send a message with the following text copy/pasted: 
```
	Another
test of \r\n\t special character's
and what they \\\ might encode/decode			as!
```
10. Validate that the message is displayed as expected within the dashboard and within the email notification.

---