### PR TITLE
Fixing comment component to use correct state property

### DIFF
--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -913,9 +913,9 @@ export const listConversations = (options) => ({
     qs: Object.assign({ limit: defaultPageLimit }, options)
   }
 });
-export const getConversations = (payload) => ({
+export const getStepConversation = (payload) => ({
   [CALL_API]: {
-    type: types.CONVERSATIONS,
+    type: types.CONVERSATION,
     method: 'GET',
     path: `notification/conversation/${payload.conversation_id}?detailed=${payload.level}&step_name=${payload.step_name}`,
     body: payload

--- a/app/src/js/components/Comments/comments.js
+++ b/app/src/js/components/Comments/comments.js
@@ -7,7 +7,7 @@ import {
   getRequest,
   replyConversation,
   getForm,
-  getConversations,
+  getStepConversation,
   getUser,
   getRole
 } from '../../actions';
@@ -53,12 +53,12 @@ class Comment extends React.Component {
         reviewStepName = '';
       }
       const payload = { conversation_id: this.props.requests.detail.data.conversation_id, level: true, step_name: reviewStepName };
-      await dispatch(getConversations(payload)).then(() => {
-        for (const ea in this.props.conversations.list.data.notes) {
-          const note = this.props.conversations.list.data.notes[ea].text.split('Comment: ')[1];
-          const author = this.props.conversations.list.data.notes[ea].from.name;
-          const viewer_users = this.props.conversations.list.data.notes[ea].viewers.users;
-          const viewer_roles = this.props.conversations.list.data.notes[ea].viewers.roles;
+      await dispatch(getStepConversation(payload)).then(() => {
+        for (const ea in this.props.conversations.conversation.data.notes) {
+          const note = this.props.conversations.conversation.data.notes[ea].text.split('Comment: ')[1];
+          const author = this.props.conversations.conversation.data.notes[ea].from.name;
+          const viewer_users = this.props.conversations.conversation.data.notes[ea].viewers.users;
+          const viewer_roles = this.props.conversations.conversation.data.notes[ea].viewers.roles;
           let viewers = [];
           viewer_users && viewer_users.forEach( function(user){
             viewers.push(user.name)
@@ -259,11 +259,11 @@ class Comment extends React.Component {
         }
       }
     }
-    if (!request || request.inflight || !this.props.conversations.list.data.notes) {
+    if (!request || request.inflight || !this.props.conversations.conversation.data.notes) {
       return <Loading />;
     } else {
       if (conversationId === '') {
-        conversationId = this.props.conversations.list.data.id;
+        conversationId = this.props.conversations.conversation.data.id;
       }
       return (
         <section className='page_section'>


### PR DESCRIPTION

# Description
Issue with /conversations page displaying error was traced to the comment component. 

An API call in the comment component was using an incorrect type causing the wrong state property to be updated. This resulted in the wrong data type being present in that property when navigating to the conversations page which resulted in the error.


## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1307

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new request
4. Fill out the request and submit (skipping this step will result in step comments not displaying on review pages)
5. Click on the DAR Form Review button
6. Leave a comment
7. At the top of the screen click the conversations tab
8. Verify the page loads without error

---
