### PR TITLE
EDPUB-1344: Conversation Notes Should Wrap

### DIFF
--- a/app/src/js/components/Conversations/conversation.js
+++ b/app/src/js/components/Conversations/conversation.js
@@ -388,21 +388,37 @@ const Note = ({ dispatch, note, conversationId, privileges }) => {
             note.viewers.users.map((user) => {
               return (
                 <div key={user.id} className='flex__row sm-border'>
-                  <div className='flex__item--w-15'>
-                    {user.name}
-                  </div>
-                  <div className='flex__item--w-15'>
-                    {canRemoveUser &&
-                      <button
-                        className='button button--remove button__animation--md button__arrow button__arrow--md button__animation'
-                        onClick={(e) => { e.preventDefault(); handleRemove(dispatch, conversationId, note.id, user.id, 'user'); }}
-                        >
-                        Remove
-                      </button>
-                    }
-                  </div>
-                </div>
+                  <div className='flex__item--w-15' style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '190px' }}>
+                      <style>
+                        {`                   
+                          .flex__item--w-15 .button--remove {
+                            color: white;
+                          }
+                          
+                          .flex__item--w-15 .button--remove:hover::before {
+                            color: white;
+                            background-color: #2c3e50;
+                            visibility: visible;
+                          }
 
+                          .flex__item--w-15 .button--remove:hover {
+                            background-color: #2c3e50;
+                          }
+                        `}
+                      </style>
+                      <span style={{ width: '150px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }} title={user.name}>
+                        {user.name} 
+                      </span>
+                      {canRemoveUser && (
+                        <button
+                          className='button button--remove'
+                          onClick={(e) => { e.preventDefault(); handleRemove(dispatch, conversationId, note.id, user.id, 'user'); }}
+                          style={{ marginLeft: '2px', padding: '0px 10px 20px 25px'}}
+                        >
+                        </button>
+                      )}
+                    </div>
+                </div>
               )
             })
           }   
@@ -411,21 +427,23 @@ const Note = ({ dispatch, note, conversationId, privileges }) => {
             note.viewers.roles.map((role) => {
               return (
                 <div key={role.id} className='flex__row sm-border'>
-                  <div className='flex__item--w-15'>
-                    {role.name}
-                  </div>
-                  <div className='flex__item--w-15'>
-                    {canRemoveUser &&
-                      <button
-                        className='button button--remove button__animation--md button__arrow button__arrow--md button__animation'
-                        onClick={(e) => { e.preventDefault(); handleRemove(dispatch, conversationId, note.id, role.id, 'role'); }}
-                        >
-                        Remove
-                      </button>
-                    }
-                  </div>
+                <div className='flex__item--w-15' style={{ display: 'flex', justifyContent: 'space-between', width: '190px' }}>
+                  <span style={{ width: '150px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }} title={role.name} >
+                    {role.name} 
+                  </span>
+                  {canRemoveUser && (
+                    <button
+                      className='button button--remove'
+                      onClick={(e) => {
+                        e.preventDefault();
+                        handleRemove(dispatch, conversationId, note.id, role.id, 'role');
+                      }}
+                      style={{ marginLeft: '2px', padding: '0px 10px 20px 25px'}}
+                    >          
+                    </button>
+                  )}
                 </div>
-
+              </div>             
               )
             })
           }              
@@ -451,7 +469,7 @@ const Note = ({ dispatch, note, conversationId, privileges }) => {
         </div>
       </div>
       { showSearch && <SearchModal { ...searchOptions[searchType] }/> }
-      <div className='flex__item--grow-1-wrap'style={{whiteSpace: "pre"}}>{ decodeURI(note.text) }</div>
+      <div className='flex__item--grow-1-wrap'style={{whiteSpace: "pre-wrap", overflowWrap: "break-word"}}>{ decodeURI(note.text) }</div>
     </div>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -7504,9 +7504,9 @@
       "integrity": "sha512-G7j3UCOukFtxVO1vWrPQUoDk3kL70mtvjc/DC/k2o7lE0wAdq+Vwp1ipagOow+BH0uVztFysLWbkM/RTIrbK3w=="
     },
     "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "version": "6.5.7",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+      "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "style-loader": "^3.3.1"
   },
   "overrides": {
-    "yaml": "2.2.2"
+    "yaml": "2.2.2",
+    "elliptic":"6.5.7"
   }
 }


### PR DESCRIPTION
# Description

[add description of work done here]

## Spec

Designs: Conversation Notes Should Wrap
Specific conversation notes (i.e. conversations/id/{id}) should wrap instead of extending past the right of the screen display.


See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1344

---

## Validation

1. Conversation Notes Should Wrap
2. Click on Conversations tab -> click on ALL -> if there are any text then it will wrap 
