### PR TITLE
Hiding links to forms that are daac_only

### DIFF
--- a/app/src/js/components/FormQuestions/questions.js
+++ b/app/src/js/components/FormQuestions/questions.js
@@ -146,6 +146,14 @@ const FormQuestions = ({
 
   useEffect(() => {
     if (formData) {
+      if (formData.error){
+        setAlertVariant('danger');
+        setAlertMessage(
+          'Unable to fetch form data. If you believe this is an error please contact the EDPub team.'
+        );
+        setDismissCountDown(10);
+        return;
+      }
       setQuestions(formData.sections);
       const initialValues = {};
       formData.sections.forEach((section) => {
@@ -1287,7 +1295,7 @@ const FormQuestions = ({
           <h3
             id="daac_selection"
             style={{
-              display: daacInfo && daacInfo.daac_name !== '' ? 'block' : 'none',
+              display: daacInfo && daacInfo.daac_name && daacInfo.daac_name !== '' ? 'block' : 'none',
               textAlign: 'left',
             }}
           >

--- a/app/src/js/utils/privileges.js
+++ b/app/src/js/utils/privileges.js
@@ -197,6 +197,21 @@ export const questionPrivileges = (privileges) => {
   };
 };
 
+export const daacPrivileges = (privileges) => {
+  if (privileges.ADMIN) {
+    return {
+      canRead: true,
+    };
+  } else if (privileges.DAAC) {
+    return {
+      canRead: privileges.DAAC.includes('READ'),
+    };
+  }
+  return {
+    canRead: false
+  };
+};
+
 /**
  * given an array of privileges (strings), return an object with keys as the type of privilege and values as an array of actions
  * 


### PR DESCRIPTION
# Description

Dashboard updates for disabling links when a form is daac_only

## Spec


See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1333

Related PR:
https://github.com/eosdis-nasa/earthdata-pub-api/pull/131

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. In local DB set DAR form to daac_only
4. Create a new request as a data producer and verify that the next step button is not active
5. Navigate to the request page
6. Verify that the next step option is not present there either
