### PR TITLE
Addressing issue with step approval comments

### DIFF
--- a/app/src/js/components/Comments/comments.js
+++ b/app/src/js/components/Comments/comments.js
@@ -47,7 +47,9 @@ class Comment extends React.Component {
     await dispatch(getForm(formId, this.props.requests.detail.data.daac_id));
     let reviewStepName = `${this.props.forms.map[formId].data.short_name}_form_review`;
     if (this.props.requests.detail.data.conversation_id) {
-      if (typeof this.props.forms.map[formId].data.short_name === 'undefined' && typeof step !== 'undefined') {
+      if ( typeof this.props.requests.detail.data.step_name !== 'undefined' && typeof step === 'undefined'){
+        reviewStepName = this.props.requests.detail.data.step_name;
+      } else if (typeof this.props.forms.map[formId].data.short_name === 'undefined' && typeof step !== 'undefined') {
         reviewStepName = step;
       } else if (typeof this.props.forms.map[formId].data.short_name === 'undefined') {
         reviewStepName = '';


### PR DESCRIPTION
# Description

Fixes issue where step comments were not being displayed properly for review steps that weren't directly tied to a form. This was most noticeable in the GES DISC workflow for the UWG/Management/ESDIS review steps.

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1381

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
4. Create a new request and select GES DISC as the DAAC
5. Fill out & submit the DPR form or move the form to the UWG Review step from the request page
6. Make a comment on the UWG Review page and save
7. Refresh the page and verify that the comment still displays.
8. Approve the request
9. On the Management Review page leave a comment and reject the approval
10. Verify that the comments on the UWG Review are still correct & re-approve the form
11. Verify that the comments on the Management Review page are correct

---