### PR TITLE
Edpub 1297 split uploads

### DIFF
--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -338,7 +338,7 @@ class UploadOverview extends React.Component {
                     marginRight: '15px',
                   }}>
                     <input type="radio" id="documentation_category" name="category" value="documentation" onClick={() => this.setCategoryType("documentation")}/>
-                    <label className="diff" style={{ marginLeft: '5px', marginBottom: '0px', fontSize: '1em' }} htmlFor="documentation">Documentation</label>
+                    <label style={{ marginLeft: '5px', marginBottom: '0px', fontSize: '1em' }} htmlFor="documentation">Documentation</label>
                   </label>
                   <label
                     style={{
@@ -348,7 +348,7 @@ class UploadOverview extends React.Component {
                     }}
                   >
                     <input type="radio" id="sample_category" name="category" value="sample" onClick={() => this.setCategoryType("sample")}/>
-                    <label className="diff" style={{ marginLeft: '5px', marginBottom: '0px', fontSize: '1em' }} htmlFor="sample">Sample Files</label>
+                    <label style={{ marginLeft: '5px', marginBottom: '0px', fontSize: '1em' }} htmlFor="sample">Sample Files</label>
                   </label>
                 </div>
                 <br />

--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -29,7 +29,8 @@ class UploadOverview extends React.Component {
       uploadFailed: false,
       uploadFileName: '',
       error: '',
-      file: null
+      file: null,
+      categoryType: null
     };
     this.handleClick = this.handleClick.bind(this);
     this.handleChange = this.handleChange.bind(this);
@@ -174,11 +175,6 @@ class UploadOverview extends React.Component {
       const { apiRoot } = _config;
 
       let category = document.querySelector('input[name="category"]:checked')?.value;
-      if (requestId !== '' && requestId != undefined && requestId !== null && typeof category === 'undefined'){
-        this.setState({ statusMsg: 'You  must select a document type before uploading the file'});
-        return
-      }
-
       try {
         let payload = {
           fileObj: file,
@@ -209,6 +205,7 @@ class UploadOverview extends React.Component {
           this.setState({ uploadFailed: true, error: error});
           if (typeof category !== 'undefined') {
             document.querySelector('input[name="category"]:checked').checked = false;
+            this.setCategoryType(undefined);
           }
         } else {
           this.setState({ statusMsg: 'Upload Complete', progressValue: 0, uploadFileName: '' });
@@ -219,6 +216,7 @@ class UploadOverview extends React.Component {
           }
           if (typeof category !== 'undefined') {
             document.querySelector('input[name="category"]:checked').checked = false;
+            this.setCategoryType(undefined);
           }
         }
       } catch (error) {
@@ -227,6 +225,7 @@ class UploadOverview extends React.Component {
         this.resetInputWithTimeout('Select a file', 1000)
         if (typeof category !== 'undefined') {
           document.querySelector('input[name="category"]:checked').checked = false;
+          this.setCategoryType(undefined);
         }
       }
     }
@@ -245,6 +244,10 @@ class UploadOverview extends React.Component {
     e.preventDefault();
     this.setState({file: e.target.files[0]})
     dispatch(refreshToken());
+  }
+
+  async setCategoryType(e) {
+    this.setState({categoryType: e});
   }
   
 
@@ -318,8 +321,6 @@ class UploadOverview extends React.Component {
                 </>
                 : null
               }
-               <span style={{ paddingBottom: '1rem' }}>{this.state.statusMsg === 'Uploading' && this.state.progressValue == 0 ? <Loading /> : this.state.uploadFileName}</span>
-              
               {this.state.showProgressBar && this.state.progressValue > 0 && 
                 <div style={progressBarStyle}>
                   <div style={progressBarFillStyle}>
@@ -329,15 +330,15 @@ class UploadOverview extends React.Component {
               <div>
               {requestId !== undefined ?
                 <>
-                <p>File Category:</p>
+                <p style={{fontWeight: '600'}}>Select File Category:</p>
                 <div>
                   <label style={{
                     display: 'flex',
                     alignItems: 'center',
                     marginRight: '15px',
                   }}>
-                    <input type="radio" id="documentation_category" name="category" value="documentation" />
-                    <label style={{ marginLeft: '5px' }} htmlFor="documentation">Documentation</label>
+                    <input type="radio" id="documentation_category" name="category" value="documentation" onClick={() => this.setCategoryType("documentation")}/>
+                    <label className="diff" style={{ marginLeft: '5px', marginBottom: '0px', fontSize: '1em' }} htmlFor="documentation">Documentation</label>
                   </label>
                   <label
                     style={{
@@ -346,8 +347,8 @@ class UploadOverview extends React.Component {
                       marginRight: '15px',
                     }}
                   >
-                    <input type="radio" id="sample_category" name="category" value="sample" />
-                    <label style={{ marginLeft: '5px' }} htmlFor="sample">Sample Files</label>
+                    <input type="radio" id="sample_category" name="category" value="sample" onClick={() => this.setCategoryType("sample")}/>
+                    <label className="diff" style={{ marginLeft: '5px', marginBottom: '0px', fontSize: '1em' }} htmlFor="sample">Sample Files</label>
                   </label>
                 </div>
                 <br />
@@ -363,7 +364,7 @@ class UploadOverview extends React.Component {
                   ref={this.state.hiddenFileInput}
                   id="hiddenFileInput" />
               </label>
-              <button onClick={(e) => this.handleClick(e)} className={'button button--submit button__animation--md button__arrow button__arrow--md button__animation button__arrow--white'}>Upload File</button>
+              <button onClick={(e) => this.handleClick(e)} className={`button button__animation--md button__arrow button__arrow--md button__animation button__arrow--white ${this.state.categoryType ? 'button--submit' : 'button--secondary button--disabled'}`}>Upload File</button>
             </div>
             {this.state.saved && requestId !== undefined && groupId === undefined
               ?

--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -322,6 +322,8 @@ class UploadOverview extends React.Component {
                   </div>
                 </div>}
               <div>
+              {requestId !== undefined ?
+                <>
                 <p>File Category:</p>
                 <div>
                   <label style={{
@@ -344,6 +346,8 @@ class UploadOverview extends React.Component {
                   </label>
                 </div>
                 <br />
+                </>: null
+              }
               </div>
               <label htmlFor='hiddenFileInput' style={{ marginBottom: '1rem', fontSize: 'unset' }}>{`${this.state.statusMsg}`}
                 <input

--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -159,6 +159,11 @@ class UploadOverview extends React.Component {
   }
 
   async uploadFile(){
+    let category = document.querySelector('input[name="category"]:checked')?.value;
+    if (typeof category === 'undefined'){
+      this.setState({ statusMsg: 'You  must select a document type before uploading the file'});
+      return
+    }
     const file = this.state.file
     if (this.validateFile(file)) {
       this.setState({ statusMsg: 'Uploading', showProgressBar: true, progressValue: 0, uploadFileName: file ? file.name: '' });
@@ -266,14 +271,19 @@ class UploadOverview extends React.Component {
         width: '100px'
       },
       {
+        Header: 'Category',
+        accessor: row => row.category.charAt(0).toUpperCase() + row.category.substring(1).toLowerCase(),
+        id: 'category',
+      },
+      {
         Header: 'sha256Checksum',
         accessor: row => row.sha256Checksum,
         id: 'sha256Checksum'
       },
       {
         Header: 'Last Modified',
-        accessor: row => shortDateShortTimeYearFirstJustValue(row.last_modified),
-        id: 'last_modified'
+        accessor: row => shortDateShortTimeYearFirstJustValue(row.lastModified),
+        id: 'lastModified'
       }
     ];
     const { requestId } = this.props.match.params;
@@ -305,6 +315,30 @@ class UploadOverview extends React.Component {
                     <span style={numberDisplayStyle}>{this.state.uploadFailed ? <span>{'Upload Failed'}<span className="info-icon" data-tooltip={this.state.error}></span></span>: `${this.state.progressValue}%`}</span>
                   </div>
                 </div>}
+              <div>
+                <p>File Category:</p>
+                <div>
+                  <label style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    marginRight: '15px',
+                  }}>
+                    <input type="radio" id="documentation_category" name="category" value="documentation" />
+                    <label style={{ marginLeft: '5px' }} htmlFor="documentation">Documentation</label>
+                  </label>
+                  <label
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      marginRight: '15px',
+                    }}
+                  >
+                    <input type="radio" id="sample_category" name="category" value="sample" />
+                    <label style={{ marginLeft: '5px' }} htmlFor="sample">Sample Files</label>
+                  </label>
+                </div>
+                <br />
+              </div>
               <label htmlFor='hiddenFileInput' style={{ marginBottom: '1rem', fontSize: 'unset' }}>{`${this.state.statusMsg}`}
                 <input
                   onChange={(e) => this.handleChange(e)}

--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -209,7 +209,7 @@ class UploadOverview extends React.Component {
           }
         } else {
           this.setState({ statusMsg: 'Upload Complete', progressValue: 0, uploadFileName: '' });
-          this.resetInputWithTimeout('Select another file', 1000)
+          this.resetInputWithTimeout('Select a file', 1000)
           if ((requestId !== '' && requestId != undefined && requestId !== null) &&
             (groupId == '' || groupId === undefined || groupId === null)) {
             this.getFileList()

--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -208,6 +208,7 @@ class UploadOverview extends React.Component {
           console.log(`An error has occurred on uploadFile: ${error}.`);
           this.resetInputWithTimeout('Select a file', 1000)
           this.setState({ uploadFailed: true, error: error});
+          document.querySelector('input[name="category"]:checked').checked = false;
         } else {
           this.setState({ statusMsg: 'Upload Complete', progressValue: 0, uploadFileName: '' });
           this.resetInputWithTimeout('Select another file', 1000)
@@ -215,11 +216,13 @@ class UploadOverview extends React.Component {
             (groupId == '' || groupId === undefined || groupId === null)) {
             this.getFileList()
           }
+          document.querySelector('input[name="category"]:checked').checked = false;
         }
       } catch (error) {
         this.setState({ uploadFailed: true });
         console.log(`try catch error: ${error.stack}`);
         this.resetInputWithTimeout('Select a file', 1000)
+        document.querySelector('input[name="category"]:checked').checked = false;
       }
     }
   }

--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -182,6 +182,9 @@ class UploadOverview extends React.Component {
         let payload = {
           fileObj: file,
           authToken: loadToken().token,
+          endpointParams: {
+            file_category: category
+          }
         }
         let prefix = ''
         if (requestId !== '' && requestId != undefined && requestId !== null) {

--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -159,11 +159,6 @@ class UploadOverview extends React.Component {
   }
 
   async uploadFile(){
-    let category = document.querySelector('input[name="category"]:checked')?.value;
-    if (typeof category === 'undefined'){
-      this.setState({ statusMsg: 'You  must select a document type before uploading the file'});
-      return
-    }
     const file = this.state.file
     if (this.validateFile(file)) {
       this.setState({ statusMsg: 'Uploading', showProgressBar: true, progressValue: 0, uploadFileName: file ? file.name: '' });
@@ -178,18 +173,22 @@ class UploadOverview extends React.Component {
       const { groupId } = this.props.match.params;
       const { apiRoot } = _config;
 
+      let category = document.querySelector('input[name="category"]:checked')?.value;
+      if (requestId !== '' && requestId != undefined && requestId !== null && typeof category === 'undefined'){
+        this.setState({ statusMsg: 'You  must select a document type before uploading the file'});
+        return
+      }
+
       try {
         let payload = {
           fileObj: file,
-          authToken: loadToken().token,
-          endpointParams: {
-            file_category: category
-          }
+          authToken: loadToken().token
         }
         let prefix = ''
         if (requestId !== '' && requestId != undefined && requestId !== null) {
           payload['apiEndpoint'] = `${apiRoot}data/upload/getPostUrl`;
           payload['submissionId'] = requestId
+          payload['endpointParams'] = { file_category: category };
         } else if (groupId !== '' && groupId != undefined && groupId !== null) {
           if (document.getElementById('prefix') && document.getElementById('prefix') !== null) {
             prefix = document.getElementById('prefix').value
@@ -208,7 +207,9 @@ class UploadOverview extends React.Component {
           console.log(`An error has occurred on uploadFile: ${error}.`);
           this.resetInputWithTimeout('Select a file', 1000)
           this.setState({ uploadFailed: true, error: error});
-          document.querySelector('input[name="category"]:checked').checked = false;
+          if (typeof category !== 'undefined') {
+            document.querySelector('input[name="category"]:checked').checked = false;
+          }
         } else {
           this.setState({ statusMsg: 'Upload Complete', progressValue: 0, uploadFileName: '' });
           this.resetInputWithTimeout('Select another file', 1000)
@@ -216,13 +217,17 @@ class UploadOverview extends React.Component {
             (groupId == '' || groupId === undefined || groupId === null)) {
             this.getFileList()
           }
-          document.querySelector('input[name="category"]:checked').checked = false;
+          if (typeof category !== 'undefined') {
+            document.querySelector('input[name="category"]:checked').checked = false;
+          }
         }
       } catch (error) {
         this.setState({ uploadFailed: true });
         console.log(`try catch error: ${error.stack}`);
         this.resetInputWithTimeout('Select a file', 1000)
-        document.querySelector('input[name="category"]:checked').checked = false;
+        if (typeof category !== 'undefined') {
+          document.querySelector('input[name="category"]:checked').checked = false;
+        }
       }
     }
   }

--- a/app/src/js/components/FormQuestions/FileUploader.js
+++ b/app/src/js/components/FormQuestions/FileUploader.js
@@ -72,7 +72,7 @@ const FileUploader = ({ requestId, store, refreshFileList }) => {
           alertMsg = '';
           statusMsg = 'Upload Complete';
           resetUploads(alertMsg, statusMsg);
-          setTimeout(() => setUploadStatusMsg('Select another file'), 1000);
+          setTimeout(() => setUploadStatusMsg('Select a file'), 1000);
 
           if (requestId) {
             refreshFileList();

--- a/app/src/js/components/FormQuestions/questions.js
+++ b/app/src/js/components/FormQuestions/questions.js
@@ -43,7 +43,7 @@ const FormQuestions = ({
   const [dismissCountDown, setDismissCountDown] = useState(0);
   const [uploadFile, setUploadFile] = useState(null);
   const [uploadStatusMsg, setUploadStatusMsg] = useState('');
-  const [uploadedFiles, setUploadedFiles] = useState([]);
+  const [uploadedFiles, setUploadedFiles] = useState({});
   const [fakeTable, setFakeTable] = useState([{}]);
   const [validationAttempted, setValidationAttempted] = useState(false);
   const [progressValue, setProgressValue] = useState(0);
@@ -135,8 +135,18 @@ const FormQuestions = ({
           return keyB - keyA;
         });
 
+        // Filter into categories for display
+        const categoryFiles = {};
+        files.forEach((f) => {
+          if (f.category in categoryFiles){
+            categoryFiles[f.category].push(f);
+          } else {
+            categoryFiles[f.category] = [f]
+          }
+        })
+
         // Set the files in state
-        setUploadedFiles(files);
+        setUploadedFiles(categoryFiles);
       } catch (error) {
         console.error('Failed to fetch file uploads:', error);
       }
@@ -507,7 +517,10 @@ const FormQuestions = ({
                 newValidationErrors[element.controlId] = element.errorMessage;
               }
             } else if (input.type === 'file') {
-              if (uploadedFiles && uploadedFiles.length === 0) {
+              if (uploadedFiles && typeof category_map[input.control_id] !== 'undefined' &&
+                (!(category_map[input.control_id] in uploadedFiles) ||
+                (category_map[input.control_id] in uploadedFiles &&
+                uploadedFiles[category_map[input.control_id]].length === 0))) {
                 let flag;
                 question.inputs.forEach((input) => {
                   if (jsonObj.data[input.control_id]) {
@@ -1030,7 +1043,12 @@ const FormQuestions = ({
 
   const { apiRoot } = _config;
 
-  const handleUpload = async () => {
+  const category_map = {
+    "data_product_documentation": "documentation",
+    "example_files": "sample"
+  };
+
+  const handleUpload = async (control_id) => {
     setUploadStatusMsg('Uploading...');
     setShowProgressBar(true);
     setProgressValue(0);
@@ -1046,12 +1064,16 @@ const FormQuestions = ({
       const upload = new localUpload();
       const requestId = daacInfo.id;
 
+      let uploadCategory = typeof category_map[control_id] !== 'undefined' ? category_map[control_id] : "";
       try {
         //await refreshAuth(); // Function to refresh authentication token if needed
 
         let payload = {
           fileObj: uploadFile,
           authToken: localStorage.getItem('auth-token'),
+          endpointParams: {
+            file_category: uploadCategory
+          }
         };
 
         if (requestId) {
@@ -2205,7 +2227,7 @@ const FormQuestions = ({
                                             display: input.type === 'file' ? 'block' : 'none',
                                           }}
                                           className="upload-button mt-2"
-                                          onClick={handleUpload}
+                                          onClick={(e) => handleUpload(input.control_id)}
                                           disabled={!uploadFile}
                                         >
                                           Upload
@@ -2227,8 +2249,11 @@ const FormQuestions = ({
                                               </tr>
                                             </thead>
                                             <tbody>
-                                              {uploadedFiles.length > 0 ? (
-                                                uploadedFiles.map((file, index) => (
+                                              {Object.keys(uploadedFiles).length > 0 && 
+                                              typeof category_map[input.control_id] !== 'undefined' &&
+                                              category_map[input.control_id] in uploadedFiles &&
+                                              uploadedFiles[category_map[input.control_id]].length > 0 ? (
+                                                uploadedFiles[category_map[input.control_id]].map((file, index) => (
                                                   <tr
                                                     key={index}
                                                     className="uploaded-files-row"


### PR DESCRIPTION
# Description

Front end changes for splitting uploads into sample/documentation buckets

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1297

Related PR: https://github.com/eosdis-nasa/earthdata-pub-api/pull/136

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches to SIT.
3. Navigate to the request overview page for a new or existing request
4. Select documentation and click upload to select a file
5. Verify that the file shows the correct category in the table after upload
6. Navigate to the DAR form
7. Verify previously uploaded file shows up in the documentation section
8. Attempt to save the form and verify that a red box appears around the sample file question
9. Upload a file to the sample files
10. Save the form and verify that the red box has disappeared

---

## Change Log

* Added upload split by category