### PR TITLE
Hotfix: Enabled group upload by default and disable during upload

### DIFF
--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -202,6 +202,8 @@ class UploadOverview extends React.Component {
         this.setState({ statusMsg: 'Uploading', uploadFailed: false });
         const resp = await upload.uploadFile(payload, updateProgress);
 
+        this.setState({showProgressBar: false, progressValue: 0, uploadFileName: ''})
+
         let error = resp?.data?.error || resp?.error || resp?.data?.[0]?.error
         if (error) {
           console.log(`An error has occurred on uploadFile: ${error}.`);
@@ -211,7 +213,7 @@ class UploadOverview extends React.Component {
             this.resetRadioState();
           }
         } else {
-          this.setState({ statusMsg: 'Upload Complete', progressValue: 0, uploadFileName: '' });
+          this.setState({ statusMsg: 'Upload Complete' });
           this.resetInputWithTimeout('Select a file', 1000)
           if ((requestId !== '' && requestId != undefined && requestId !== null) &&
             (groupId == '' || groupId === undefined || groupId === null)) {
@@ -365,7 +367,7 @@ class UploadOverview extends React.Component {
                   ref={this.state.hiddenFileInput}
                   id="hiddenFileInput" />
               </label>
-              <button onClick={(e) => this.handleClick(e)} className={`button button__animation--md button__arrow button__arrow--md button__animation button__arrow--white ${this.state.categoryType ? 'button--submit' : 'button--secondary button--disabled'}`}>Upload File</button>
+              <button onClick={(e) => this.handleClick(e)} className={`button button__animation--md button__arrow button__arrow--md button__animation button__arrow--white ${!this.state.showProgressBar && (this.state.categoryType  || requestId === undefined) ? 'button--submit' : 'button--secondary button--disabled'}`}>Upload File</button>
             </div>
             {this.state.saved && requestId !== undefined && groupId === undefined
               ?


### PR DESCRIPTION
# Description

Add condition where upload button is disabled during upload but enabled if requestId is undefined

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Push the branches to SIT.
3. Ensure that the file upload button in the ghrc_daac group is enabled by default.
4. Ensure that the file upload button on the request details page is disabled until a category is selected.
5. Ensure that the file upload button is disabled during upload.

_(For an example of good validation instructions, check out
[Bryan's Bouncy Ball PR](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701).)_

---