### PR TITLE
resolving missing step name when form is incomplete

### DIFF
--- a/app/src/js/components/Comments/comments.js
+++ b/app/src/js/components/Comments/comments.js
@@ -199,21 +199,16 @@ class Comment extends React.Component {
   render() {
     let reviewable = false;
     let sameFormAsStep = false;
-    const search = this.props.location.search.split('=');
-    let requestId = '';
-    if (search[1] !== undefined) {
-      requestId = search[1].replace(/&step/g, '');
-    }
-    let step = search[2];
+    let request = this.props.requests.detail.data;
+    let requestId = request ? request.id : '';
+    let step = request?.step_name;
     let stepName = this.getFormalName(step);
     let { canReview } = requestPrivileges(this.props.privileges, step);
     const { canAddUser, canRemoveUser } = notePrivileges(this.props.privileges);
-    let request = '';
     let conversationId = '';
     let requestName = '';
     const formId = this.props.match.params.formId;
-    let formName = '';
-    request = this.props.requests.detail.data;
+    let formName = '';    
     const searchOptions = {
       user: {
         entity: 'user',
@@ -230,10 +225,6 @@ class Comment extends React.Component {
       if (this.props.forms.map !== undefined && this.props.forms.map[formId] !== undefined && this.props.forms.map[formId].data !== undefined) {
         formName = this.props.forms.map[formId].data.short_name;
         if (this.props.requests.detail.data.forms !== null) {
-          if (step === undefined) {
-            step = this.props.requests.detail.data.step_name;
-            stepName = this.getFormalName(step);
-          }
           if (this.props.requests.detail.data.form_data?.data_product_name_value) {
             requestName = this.props.requests.detail.data.form_data.data_product_name_value;
           } else {
@@ -241,19 +232,19 @@ class Comment extends React.Component {
           }
         }
         conversationId = this.props.requests.detail.data.conversation_id;
-        if (this.props.requests.detail.data.step_name?.match(/close/g)) {
+        if (step?.match(/close/g)) {
           sameFormAsStep = false;
           canReview = false;
         }
-        if (this.props.requests.detail.data.step_name === `${formName}_form`) {
+        if (step === `${formName}_form`) {
           sameFormAsStep = true;
           canReview = false;
-        } else if (this.props.requests.detail.data.step_name?.match(/form_(.*_)?review/g)) {
+        } else if (step?.match(/form_(.*_)?review/g)) {
           if (canReview) {
             reviewable = true;
           }
           const regexStr = new RegExp(`${formName}_form_(.*_)?review`, 'g');
-          if (this.props.requests.detail.data.step_name?.match(regexStr)) {
+          if (step?.match(regexStr)) {
             sameFormAsStep = true;
           }
         } else if (window.location.href.match(/approval/g)) {


### PR DESCRIPTION
# Description

Step name was not being passed properly when forms were skipped which resulted in missing comments on the review pages and missing step names on the conversations page. This PR resolves the issue and ensures that the step name is properly passed regardless of whether the form has been filled in or not.

## Spec

See Ticket: https://bugs.earthdata.nasa.gov/browse/EDPUB-1423

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Start a new request
4. On the request overview page, change the current step to the DPR review step
5. Navigate to the DPR review page
6. Submit a review comment
7. Refresh page
8. Validate that the comment is still visible. 
9. Navigate to the conversations page for the request and validate that the correct step name is associated with the note.

---

## Change Log

* Fix missing step names when skipping form completion