### PR TITLE
Updating dashboard to repurpose daac selection page for daac assignment

### DIFF
--- a/app/src/js/App.js
+++ b/app/src/js/App.js
@@ -60,7 +60,7 @@ const MainRoutes = ({ activeRoute }) => {
     { path: '/forms', component: Forms },
     { path: '/inputs', component: Input },
     { path: '/sections', component: Sections },
-    { path: '/daac/selection', component: FormRequest },
+    { path: '/daac/assignment', component: FormRequest },
     { path: '/form/questions/:id', component: FormQuestions },
     { path: '/questions', component: Questions },
     { path: '/users', component: Users },

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -1286,3 +1286,12 @@ export const addStep = (payload) => ({
 });
 
 export const setAuthenticatedState = (authenticated) => ({ type: types.SET_TOKEN, authenticated });
+
+export const assignDaacs = (payload) => ({
+  [CALL_API]: {
+    type: types.REQUEST,
+    method: 'POST',
+    path: '/api/data/submission/operation/assignDaacs',
+    body: payload
+  }
+});

--- a/app/src/js/components/FormRequest/index.js
+++ b/app/src/js/components/FormRequest/index.js
@@ -10,7 +10,7 @@ import { strings } from '../locale';
 class FormRequest extends React.Component {
   constructor () {
     super();
-    this.displayName = 'DAAC Selection';
+    this.displayName = 'DAAC Assignment';
   }
 
   render () {
@@ -20,16 +20,16 @@ class FormRequest extends React.Component {
       <div className='page__forms'>
         <div className='content__header'>
           <div className='row'>
-            <h1 className='heading--xlarge heading--shared-content'>DAAC Selection</h1>
+            <h1 className='heading--xlarge heading--shared-content'>DAAC Assignment</h1>
           </div>
         </div>
         <div className='page__content'>
           <div className='wrapper__sidebar'>
             <div className={showSidebar ? 'page__content--shortened' : 'page__content'}>
               <Switch>
-                <Route exact path='/daac/selection' component={FormsOverview} />
-                <Route exact path='/daac/selection/:daacid' component={FormsOverview} />
-                <Route path='/daac/selection/id/:formId' component={FormOverview} />
+                <Route exact path='/daac/assignment' component={FormsOverview} />
+                <Route exact path='/daac/assignment/:requestId' component={FormsOverview} />
+                {/* <Route path='/daac/selection/id/:formId' component={FormOverview} /> */}
                 <Route path='/questions/:id' component={FormsOverview} />
               </Switch>
             </div>

--- a/app/src/js/utils/privileges.js
+++ b/app/src/js/utils/privileges.js
@@ -103,7 +103,8 @@ export const requestPrivileges = (privileges, stepName) => {
       canWithdraw: true,
       canRestore: true,
       canAddUser: true,
-      canRemoveUser: true
+      canRemoveUser: true,
+      canAssignDaac: true
     };
   } else if (privileges.REQUEST) {
     return {
@@ -123,6 +124,7 @@ export const requestPrivileges = (privileges, stepName) => {
         a === 'DAACREAD' || a === 'ADMINREAD'),
       canAddUser: privileges.REQUEST.includes('ADDUSER'),
       canRemoveUser: privileges.REQUEST.includes('REMOVEUSER'),
+      canAssignDaac: privileges.REQUEST.includes('ASSIGNDAAC')
     };
   }
   return {
@@ -138,7 +140,8 @@ export const requestPrivileges = (privileges, stepName) => {
     canWithdraw: false,
     canRestore: false,
     canAddUser: false,
-    canRemoveUser: false
+    canRemoveUser: false,
+    canAssignDaac: false
   };
 };
 

--- a/app/src/js/utils/table-config/requests.js
+++ b/app/src/js/utils/table-config/requests.js
@@ -193,7 +193,7 @@ export const stepLookup = (row) => {
           if (stepName.match(/assign_a_workflow/g)){
             request = `/workflows?requestId=${row.id}`;
           } else if (stepName.match(/daac_assignment/g)) {
-            request = `${basepath}daac/assignment/${row.id}`;
+            request = `/daac/assignment/${row.id}`;
           }
         }
         break;

--- a/app/src/js/utils/table-config/requests.js
+++ b/app/src/js/utils/table-config/requests.js
@@ -90,6 +90,25 @@ export const assignWorkflow = (request, formalName) => {
   }
 };
 
+export const assignDaacs = (request, formalName) => {
+  const allPrivs = getPrivileges();
+  let disabled = false;
+  if (typeof allPrivs !== 'undefined' && ( typeof allPrivs.isAdmin !== 'undefined' || allPrivs.canAssignDaac === true)) {
+    disabled = false;
+  } else {
+    disabled = true;
+  }
+  const isDetailPage = location.href.match(/id/g);
+  if (isDetailPage === null && disabled) {
+    return <Link to={'#'} className={'button button--medium button--clear form-group__element--left button--no-icon assign-workflow'} aria-label={formalName}>{formalName}</Link>;
+  } else if (disabled) {
+    return formalName;
+  } else {
+    return <Link className={'button button--medium button--green form-group__element--left button--no-icon assign-workflow'}
+               to={`${request}`} name={'assignButton'} aria-label={formalName || 'DAAC assignment'}>{formalName}</Link>;
+  }
+};
+
 export const existingLink = (row, formId, formalName, step, stepType) => {
   const allPrivs = getPrivileges(step);
   let disabled = false;
@@ -169,9 +188,13 @@ export const stepLookup = (row) => {
             request = `${basepath}form/questions/${row.id}`;
           } 
           
-        // assign a workflow
+        // handle actions
         } else if (stepType.match(/action/g)) {
-          request = `/workflows?requestId=${row.id}`;
+          if (stepName.match(/assign_a_workflow/g)){
+            request = `/workflows?requestId=${row.id}`;
+          } else if (stepName.match(/daac_assignment/g)) {
+            request = `${basepath}daac/assignment/${row.id}`;
+          }
         }
         break;
       }
@@ -179,6 +202,8 @@ export const stepLookup = (row) => {
   }
   if (stepType.match(/action/g) && stepName.match(/assign_a_workflow/g)) {
     return assignWorkflow(request, formalName);
+  } else if (stepType.match(/action/g) && stepName.match(/daac_assignment/g)) {
+    return assignDaacs(request, formalName);
   } else if (stepType.match(/action/g)) {
     return existingLink(row, undefined, formalName, stepName);
   } else if (stepType.match(/review/g) || stepType.match(/service/g)) {


### PR DESCRIPTION
# Description

Dashboard updates for handling DAAC Selection as part of the Accession Workflow.

## Spec

Related Work:
- https://github.com/eosdis-nasa/earthdata-pub-api/pull/175

Unblocks:
- https://github.com/eosdis-nasa/earthdata-pub-api/pull/147

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Click New Request -> Data Accession Request Submission
4. Move the request ahead to the DAAC Assignment workflow step.
5. Select one or more DAACs to assign & Select
6. Verify that the submission has moved to closed
7. Verify in db viewer of choice that an entry has been added to the code table for each selected DAAC.

---

## Change Log

* Adds Dashboard updates for DAAC Assignment