### PR TITLE
Fix submit form missing privilege

### DIFF
--- a/app/src/js/utils/table-config/requests.js
+++ b/app/src/js/utils/table-config/requests.js
@@ -54,7 +54,7 @@ export const newLink = (request, formalName) => {
   let disabled = false;
   if (request == '') {
     disabled = true;
-  } else if (typeof allPrivs !== 'undefined' && allPrivs.canUpdateForm) {
+  } else if (typeof allPrivs !== 'undefined' && allPrivs.canSubmit) {
     disabled = false;
   } else {
     disabled = true;


### PR DESCRIPTION
Currently next action button will not display for DAAC staff & Data Producers for filling out forms. This update resolves that.