### PR TITLE
Edpub-1445: Fix async note refresh issue

### DIFF
--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -1083,7 +1083,7 @@ export const createConversation = (payload) => ({
   }
 });
 
-export const replyConversation = (payload) => {
+export const replyConversation = (payload, level = false) => {
   return (dispatch) => {
     dispatch({
       [CALL_API]: {
@@ -1095,7 +1095,7 @@ export const replyConversation = (payload) => {
     })
       .then(() => {
         setTimeout(() => {
-          dispatch(getConversation(payload.conversation_id));
+          dispatch(getConversation(payload.conversation_id, level));
         }, 2000);
       });
   };

--- a/app/src/js/components/Conversations/attachment.js
+++ b/app/src/js/components/Conversations/attachment.js
@@ -4,31 +4,41 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPaperclip, faFile, faTimesCircle } from '@fortawesome/free-solid-svg-icons';
 import { handleUpload } from '../../utils/upload';
 
-export const DisplayAttachmentButton = ({fileName, removeFileHandler}) => {
+export const DisplayAttachmentButton = ({ fileName, removeFileHandler }) => {
     return (
         <button type="button" className='attachment-display-button'>
-            <FontAwesomeIcon icon={faFile}  style={{paddingRight: "10px"}}/>
+            <FontAwesomeIcon icon={faFile} style={{ paddingRight: "10px" }} />
             {fileName}
-            <FontAwesomeIcon icon={faTimesCircle} style={{paddingLeft: "10px"}} onClick={(e) => {removeFileHandler(fileName)}}/>
+            <FontAwesomeIcon icon={faTimesCircle} style={{ paddingLeft: "10px" }} onClick={() => removeFileHandler(fileName)} />
         </button>
     );
-}
+};
 
-export const AddAttachmentButton = ({conversationId, uploadedFilesRef, setUploadedFiles}) => {
+export const AddAttachmentButton = ({ conversationId, uploadedFilesRef, setUploadedFiles }) => {
     useImperativeHandle(uploadedFilesRef, () => ({
         getUploadedFiles: () => uploadedFiles
     }));
 
-    let uploadedFiles = new Set([]);
+    let uploadedFiles = new Set();
 
     const handleChange = async (e) => {
         e.preventDefault();
-        uploadedFiles = new Set([...uploadedFiles, ...Array.from(e.target.files)]);
+        const newFiles = Array.from(e.target.files).map(file => {
+            const sanitizedFile = new File([file], file.name.replace(/,/g, "_"), { type: file.type });
+            return sanitizedFile;
+        });
+
+        uploadedFiles = new Set([...uploadedFiles, ...newFiles]);
+
         const resp = await handleUpload({
-            files: uploadedFiles,
+            files: [...uploadedFiles],
             conversationId
         });
-        setUploadedFiles((currentState) => new Set([...currentState, ...resp.success]));
+
+        // Store the actual files, not just names
+        setUploadedFiles((currentState) => 
+            new Set([...currentState, ...resp.success])
+        );
     };
 
     const clickFileTypeInput = () => {
@@ -37,18 +47,17 @@ export const AddAttachmentButton = ({conversationId, uploadedFilesRef, setUpload
 
     return (
         <>
-        <input 
-        id="hiddenFileInputType"
-        type="file" 
-        onChange={(e) => handleChange(e)}
-        style={{display: "none"}}
-        multiple 
-        />
-        <button type="button" className="button button--attachment" onClick={clickFileTypeInput}
-        style={{backgroundColor: "#158749", color: "white", padding: "8px" }}>
-            <FontAwesomeIcon icon={faPaperclip} />
-        </button>
+            <input 
+                id="hiddenFileInputType"
+                type="file" 
+                onChange={(e) => handleChange(e)}
+                style={{ display: "none" }}
+                multiple 
+            />
+            <button type="button" className="button button--attachment" onClick={clickFileTypeInput}
+                style={{ backgroundColor: "#158749", color: "white", padding: "8px" }}>
+                <FontAwesomeIcon icon={faPaperclip} />
+            </button>
         </>
-
     );
-}
+};

--- a/app/src/js/components/Conversations/attachment.js
+++ b/app/src/js/components/Conversations/attachment.js
@@ -24,7 +24,7 @@ export const AddAttachmentButton = ({ conversationId, uploadedFilesRef, setUploa
     const handleChange = async (e) => {
         e.preventDefault();
         const newFiles = Array.from(e.target.files).map(file => {
-            const sanitizedFile = new File([file], file.name.replace(/,/g, "_"), { type: file.type });
+            const sanitizedFile = new File([file], file.name.replace(/,/g, "-"), { type: file.type });
             return sanitizedFile;
         });
 

--- a/app/src/js/components/Conversations/conversation.js
+++ b/app/src/js/components/Conversations/conversation.js
@@ -105,7 +105,6 @@ const Conversation = ({ dispatch, conversation, privileges, match, user }) => {
         );
 
     if (isTextMatch && areAttachmentsMatch) {
-        console.log("Full match found. Replacing temp note.");
         setShouldStopRetries(true);
         setTempNotes(prevTempNotes => prevTempNotes.slice(1));
         setDisplayNotes([firstNewNote, ...notes.slice(1)]);
@@ -115,8 +114,6 @@ const Conversation = ({ dispatch, conversation, privileges, match, user }) => {
     }
 
     if (isTextMatch && !areAttachmentsMatch) {
-      console.log("Text matches but attachments don’t. Marking as pending...");
-
       setDisplayNotes(prevNotes =>
           prevNotes.map(note =>
               note.id === firstNewNote.id

--- a/app/src/js/components/Conversations/conversation.js
+++ b/app/src/js/components/Conversations/conversation.js
@@ -52,20 +52,10 @@ const Conversation = ({ dispatch, conversation, privileges, match, user }) => {
 
   const [tempNotes, setTempNotes] = useState([]);
   const [displayNotes, setDisplayNotes] = useState(data.notes);
-  const [retryCount, setRetryCount] = useState(0);
   const [shouldStopRetries, setShouldStopRetries] = useState(false);
 
   const handleVisibilityReset = () => {
     visibilityRef?.current?.resetIdMap();
-  };
-
-  const isTimeWithin = (tempSent, newSent) => {
-    if (!tempSent || !newSent) return false;
-
-    const tempDate = new Date(tempSent);
-    const newDate = new Date(newSent);
-
-    return Math.abs(tempDate - newDate) <= 20000;
   };
 
   const MAX_RETRIES = 7;
@@ -215,7 +205,7 @@ const checkForUpdates = async (retryCount = 0) => {
         attachments: [...uploadedFiles]
     };
 
-    await dispatch(replyConversation(payload));
+    await dispatch(replyConversation(payload, level));
 
     setShouldStopRetries(false);
 

--- a/app/src/js/components/Conversations/conversation.js
+++ b/app/src/js/components/Conversations/conversation.js
@@ -105,7 +105,7 @@ const Conversation = ({ dispatch, conversation, privileges, match, user }) => {
             (firstNewNote.attachments || []).some(newAtt => newAtt.trim() === att.trim())
         );
 
-    if (isTextMatch && isTimeMatch && areAttachmentsMatch) {
+    if (isTextMatch && areAttachmentsMatch) {
         console.log("Full match found. Replacing temp note.");
         setShouldStopRetries(true);
         setTempNotes(prevTempNotes => prevTempNotes.slice(1));
@@ -115,8 +115,8 @@ const Conversation = ({ dispatch, conversation, privileges, match, user }) => {
         return;
     }
 
-    if (isTextMatch && isTimeMatch && !areAttachmentsMatch) {
-      console.log("Text and time match, but attachments don't. Marking as pending...");
+    if (isTextMatch && !areAttachmentsMatch) {
+      console.log("Text match, but attachments don't. Marking as pending...");
   
       setDisplayNotes(prevNotes =>
           prevNotes.map(note =>

--- a/app/src/js/components/Conversations/conversation.js
+++ b/app/src/js/components/Conversations/conversation.js
@@ -77,15 +77,14 @@ const Conversation = ({ dispatch, conversation, privileges, match, user }) => {
 
   useEffect(() => {
     const fetchNotes = async () => {
-      const finalNotes = await dispatch(getConversation(conversationId, level));
+        const finalNotes = await dispatch(getConversation(conversationId, level));
         const updatedNotes = finalNotes?.data?.notes.map(note => ({
-          ...note,
-          isPendingAttachmentMatch: note.isPendingAttachmentMatch ?? false
-      }));
-  
-      setDisplayNotes(updatedNotes);
+            ...note,
+            isPendingAttachmentMatch: note.isPendingAttachmentMatch ?? false
+        }));
+
+        setDisplayNotes(updatedNotes);
     };
-  
 
     if (shouldStopRetries) return;
 
@@ -116,23 +115,21 @@ const Conversation = ({ dispatch, conversation, privileges, match, user }) => {
     }
 
     if (isTextMatch && !areAttachmentsMatch) {
-      console.log("Text match, but attachments don't. Marking as pending...");
-  
+      console.log("Text matches but attachments don’t. Marking as pending...");
+
       setDisplayNotes(prevNotes =>
           prevNotes.map(note =>
-              note.id === firstNewNote.id 
-                  ? { ...note, isPendingAttachmentMatch: true } 
+              note.id === firstNewNote.id
+                  ? { ...note, isPendingAttachmentMatch: true }
                   : { ...note, isPendingAttachmentMatch: note.isPendingAttachmentMatch ?? false }
           )
       );
-  
-      // Remove temp note immediately to prevent duplication
-      setTempNotes(prevTempNotes => prevTempNotes.slice(1));
-  
+
       checkForUpdates();
       return;
     }
-}, [notes, level]);
+  }, [notes, level]);
+
 
   
 const checkForUpdates = async (retryCount = 0) => {

--- a/app/src/js/components/Conversations/conversation.js
+++ b/app/src/js/components/Conversations/conversation.js
@@ -59,7 +59,7 @@ const Conversation = ({ dispatch, conversation, privileges, match, user }) => {
   };
 
   const MAX_RETRIES = 7;
-  // Retry at 3s, 10s, 20s, 35s, 50s, 65s, 80s
+  // Retry at 3rd, 8th, 18th, 33rd, 48th, 63rd, 78th second
   const RETRY_INTERVALS = [3000, 5000, 10000, 15000, 15000, 15000, 15000];
   let currentTimeout = null; // Store timeout ID
 

--- a/app/src/js/components/Conversations/note.js
+++ b/app/src/js/components/Conversations/note.js
@@ -35,17 +35,25 @@ const Note = ({ dispatch, note, conversationId, privileges, user }) => {
                 <RenderedNoteVisibility note={note} dispatch={dispatch} conversationId={conversationId} privileges={privileges} />
             </div>
             <div className='flex__item--grow-1-wrap'>
-                <div style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>
+                <div 
+                    style={{ 
+                        whiteSpace: "pre-wrap", 
+                        overflowWrap: "break-word"
+                    }}
+                >
                     {decodeURI(note.text)}
-                    {note.isPendingAttachmentMatch && (
-                        <OverlayTrigger
-                            placement="top"
-                            overlay={<Tooltip id={`tooltip-text-${note.id}`}>Attachments are still processing...</Tooltip>}
-                        >
-                            <span style={{ cursor: "not-allowed", color: "grey" }}>{'Attachments'}</span>
-                        </OverlayTrigger>
-                    )}
                 </div>
+
+                {note.isPendingAttachmentMatch && (
+                    <OverlayTrigger
+                        placement="top"
+                        overlay={<Tooltip id={`tooltip-text-${note.id}`}>Attachments are still processing...</Tooltip>}
+                    >
+                        <span style={{ cursor: "help", marginLeft: "5px", color: "grey" }}>
+                            🕒 Attachments processing...
+                        </span>
+                    </OverlayTrigger>
+                )}
 
                 {note?.attachments?.length > 0 && (
                     <>

--- a/app/src/js/components/Conversations/note.js
+++ b/app/src/js/components/Conversations/note.js
@@ -42,6 +42,7 @@ const Note = ({ dispatch, note, conversationId, privileges, user }) => {
                             placement="top"
                             overlay={<Tooltip id={`tooltip-text-${note.id}`}>Attachments are still processing...</Tooltip>}
                         >
+                            <span style={{ cursor: "not-allowed", color: "grey" }}>{'Attachments'}</span>
                         </OverlayTrigger>
                     )}
                 </div>

--- a/app/src/js/components/Conversations/note.js
+++ b/app/src/js/components/Conversations/note.js
@@ -1,4 +1,3 @@
-'use strict';
 import React from 'react';
 import PropTypes from 'prop-types';
 import localUpload from '@edpub/upload-utility';
@@ -9,7 +8,6 @@ import _config from '../../config';
 import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 const Note = ({ dispatch, note, conversationId, privileges, user }) => {
-
     const download = new localUpload();
 
     const handleDownload = ({ noteId, attachment }) => {
@@ -39,7 +37,15 @@ const Note = ({ dispatch, note, conversationId, privileges, user }) => {
             <div className='flex__item--grow-1-wrap'>
                 <div style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>
                     {decodeURI(note.text)}
+                    {note.isPendingAttachmentMatch && (
+                        <OverlayTrigger
+                            placement="top"
+                            overlay={<Tooltip id={`tooltip-text-${note.id}`}>Attachments are still processing...</Tooltip>}
+                        >
+                        </OverlayTrigger>
+                    )}
                 </div>
+
                 {note?.attachments?.length > 0 && (
                     <>
                         <br/>
@@ -54,10 +60,10 @@ const Note = ({ dispatch, note, conversationId, privileges, user }) => {
                                         </a>
                                     ) : (
                                         <OverlayTrigger
-                                        placement="top"
-                                        overlay={<Tooltip id={`tooltip-${note.id}-${idx}`}>Attachment temporarily unavailable.</Tooltip>}
+                                            placement="top"
+                                            overlay={<Tooltip id={`tooltip-${note.id}-${idx}`}>Attachment temporarily unavailable.</Tooltip>}
                                         >
-                                        <span style={{ cursor: "not-allowed", color: "grey" }}>{attachment}</span>
+                                            <span style={{ cursor: "not-allowed", color: "grey" }}>{attachment}</span>
                                         </OverlayTrigger>
                                     )}
                                 </React.Fragment>

--- a/app/src/js/components/Conversations/note.js
+++ b/app/src/js/components/Conversations/note.js
@@ -44,17 +44,6 @@ const Note = ({ dispatch, note, conversationId, privileges, user }) => {
                     {decodeURI(note.text)}
                 </div>
 
-                {note.isPendingAttachmentMatch && (
-                    <OverlayTrigger
-                        placement="top"
-                        overlay={<Tooltip id={`tooltip-text-${note.id}`}>Attachments are still processing...</Tooltip>}
-                    >
-                        <span style={{ cursor: "help", marginLeft: "5px", color: "grey" }}>
-                            🕒 Attachments processing...
-                        </span>
-                    </OverlayTrigger>
-                )}
-
                 {note?.attachments?.length > 0 && (
                     <>
                         <br/>

--- a/app/src/js/components/Conversations/note.js
+++ b/app/src/js/components/Conversations/note.js
@@ -6,40 +6,65 @@ import { lastUpdated } from '../../utils/format';
 import { RenderedNoteVisibility } from './visibility';
 import { loadToken } from '../../utils/auth';
 import _config from '../../config';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 
-const Note = ({ dispatch, note, conversationId, privileges }) => {
+const Note = ({ dispatch, note, conversationId, privileges, user }) => {
 
     const download = new localUpload();
 
-    const handleDownload = ({noteId, attachment}) => {
+    const handleDownload = ({ noteId, attachment }) => {
+        if (!noteId || noteId.startsWith('temp')) return;
+
         const { apiRoot } = _config;
-        download.downloadFile(`attachments/${noteId}/${attachment}`, `${apiRoot}data/upload/downloadUrl`, loadToken().token).then((resp) => {
-            let error = resp?.data?.error || resp?.error || resp?.data?.[0]?.error
+        download.downloadFile(
+            `attachments/${noteId}/${attachment}`, 
+            `${apiRoot}data/upload/downloadUrl`, 
+            loadToken().token
+        ).then((resp) => {
+            let error = resp?.data?.error || resp?.error || resp?.data?.[0]?.error;
             if (error) {
-              console.log(`An error has occurred: ${error}.`);
+                console.log(`An error has occurred: ${error}.`);
             }
-          })
+        });
     };
 
     return (
         <div className='flex__row--border'>
             <div className='flex__item--w-15'>
-                <h3>{note.from.name}</h3>
+                <h3>{note.from?.name || user}</h3>
                 {lastUpdated(note.sent, 'Sent')}
                 <br />
                 <RenderedNoteVisibility note={note} dispatch={dispatch} conversationId={conversationId} privileges={privileges} />
             </div>
             <div className='flex__item--grow-1-wrap'>
-                <div style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>{decodeURI(note.text)}</div>
-                {note?.attachments?.length > 0 ? <>
-                    <br/>
-                    <label>Attachments:</label>
-                    <div>
-                    {note.attachments.map((attachment) =>
-                        <div><a onClick={(e) => handleDownload({noteId: note.id, attachment})}>{attachment}</a></div>
-                    )}
-                    </div>
-                </> : null }
+                <div style={{ whiteSpace: "pre-wrap", overflowWrap: "break-word" }}>
+                    {decodeURI(note.text)}
+                </div>
+                {note?.attachments?.length > 0 && (
+                    <>
+                        <br/>
+                        <label>Attachments:</label>
+                        <div>
+                            {note.attachments.map((attachment, idx) => (
+                                <React.Fragment key={idx}>
+                                    {idx > 0 ? ', ' : ' '}
+                                    {note.id && !note.id.startsWith('temp') ? (
+                                        <a onClick={() => handleDownload({ noteId: note.id, attachment })}>
+                                            {attachment}
+                                        </a>
+                                    ) : (
+                                        <OverlayTrigger
+                                        placement="top"
+                                        overlay={<Tooltip id={`tooltip-${note.id}-${idx}`}>Attachment temporarily unavailable.</Tooltip>}
+                                        >
+                                        <span style={{ cursor: "not-allowed", color: "grey" }}>{attachment}</span>
+                                        </OverlayTrigger>
+                                    )}
+                                </React.Fragment>
+                            ))}
+                        </div>
+                    </>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
# Description

Currently, the conversations page will refresh after sending a reply. The backend move attachments operations may not yet be complete resulting in only the note text displaying after the refresh. Determine the best way of resolving this issue and implement.


## Spec

See Ticket: [EDPUB-1445](https://bugs.earthdata.nasa.gov/browse/EDPUB-1445)

---

## Validation

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Navigate to the conversation tab and try adding a new one with attachments. You should see a tooltip until the attachments are processed. 