### PR TITLE
EDPUB-1478: Update repo template assets

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: "\U0001F41B Bug Report"
+about: "If something isn't working as expected."
+title: ''
+labels: 'i: bug'
+assignees: ''
+
+---
+
+Does an issue already exist for this?
+Please search 🔍 the issues to check if this bug has already been reported.
+_Put an `x` in the box to confirm_
+
+- [ ] I have searched and no other issue reporting this bug exists.
+
+## Bug Report
+
+**Environment Detected**
+_Put an `x` in the boxes that apply_
+- [ ] Local
+- [ ] SIT
+- [ ] UAT
+- [ ] PROD
+
+**Current Behavior**
+A clear and concise description of the behavior.
+
+```
+
+```
+
+**Expected behavior/code**
+A clear and concise description of what you expected to happen (or code).
+
+```
+
+```
+
+**Possible Solution**
+<!--- Only if you have suggestions on a fix for the bug -->
+```
+
+```
+
+**Additional context/Screenshots**
+Add any other context about the problem here. If applicable, add screenshots to help explain.
+
+```
+
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: "\U0001F680 Feature Request"
+about: "I have a suggestion!"
+title: ''
+labels: 'i: enhancement'
+assignees: ''
+
+---
+
+## Feature Request
+
+**Is your feature request related to a problem?**
+A clear and concise description of what the problem is. Ex. I have an issue when [...]
+
+```
+
+```
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. Add any considered drawbacks or use cases.
+
+```
+
+```
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+```
+
+```
+
+**Additional Context**
+Provide any other context or screenshots about the feature request here.
+
+```
+
+```

--- a/.github/ISSUE_TEMPLATE/support_question.md
+++ b/.github/ISSUE_TEMPLATE/support_question.md
@@ -1,0 +1,17 @@
+---
+name: "\U0001F917 Support Question"
+about: "If you have a question \U0001F4AC, please check out our Slack!"
+title: ''
+labels: 'i: question'
+assignees: ''
+
+---
+
+We primarily use GitHub as an issue tracker; for usage and support questions, please check out these resources below. Thanks! 😁.
+
+---
+
+* Slack EOSDIS Channel: #earthdatapub
+* EDPUB Wiki Page: https://wiki.earthdata.nasa.gov/display/EDPUB/Earthdata+Pub+Home
+
+---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,45 @@
-# Description
+## Description
 
-[add description of work done here]
+Describe your work done here including any specification or design documentation followed. 
+If it fixes a bug or resolves a feature request, be sure to link to that issue.
 
-## Spec
+## Linked JIRA Task or Github Issue
 
-Designs: [link to design if applicable; delete if not]
+JIRA Task: [example](link_here)
 
-See Ticket: [link to ticket if applicable; delete if not]
+Github Issue: [example](link_here)
 
----
+## Types of changes
 
-## Validation
+What types of changes does your code introduce to Earthdata Pub (EDPub)?
+_Put an `x` in the boxes that apply_
+
+- [ ] Bugfix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation Update (if adding or updating the existing documentation resources)
+- [ ] Other (if none of the other choices apply)
+
+## Checklist
+
+_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
+
+- [ ] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
+- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
+- [ ] Lint and unit tests pass locally with my changes
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added the necessary documentation (if appropriate)
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## Validation Steps
+
+_This will help us get a jump start on validating your PR by describing the steps to replicate
+and validate the expected behavior. (For an example of good validation instructions, check out [Bryan's Bouncy Ball PR.](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701))_
 
 1. Make sure all merge request checks have passed (CI/CD).
 2. Pull related branches locally.
 3. Navigate to... [continue instructions]
 
-_(For an example of good validation instructions, check out
-[Bryan's Bouncy Ball PR](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701).)_
+## Further comments
 
----
-
-## Change Log
-
-_(copy/paste-able change log notes. check the box when the change is also in CHANGELOG.md)_
-
-* [Add _____](link to commitid)
-* [Fix _____](link to commitid)
+If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,8 +24,8 @@ _Put an `x` in the boxes that apply_
 
 _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
 
-- [ ] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
-- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
+- [ ] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
+- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
 - [ ] Lint and unit tests pass locally with my changes
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] I have added the necessary documentation (if appropriate)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Removed funny line from dropdown
 - Added error page form and routes to it if an api return (response.error.code) not 200
 - Update MFA to EDPub custom flow
+- Updated github repo template assets
 <!-- Unreleased changes can be added here. -->
 
 ## 1.0.19

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Code to generate and deploy the dashboard for the Earthdata Pub API.
 - [Branching](#branching)
 - [Releasing](#releasing)
 - [Documentation](#documentation)
+- [References](#references)
 
 ## Contributing
 
@@ -267,3 +268,9 @@ See [RELEASE.md](./RELEASE.md).
 - [Usage](./USAGE.md)
 - [Development Guide](./DEVELOPMENT.md)
 - [Technical documentation on tables](./TABLES.md)
+
+## References
+
+- EOSDIS Slack Channel: #earthdatapub
+- EDPub Wiki: [https://wiki.earthdata.nasa.gov/display/EDPUB/Earthdata+Pub+Home](https://wiki.earthdata.nasa.gov/display/EDPUB/Earthdata+Pub+Home)
+- EDPub Roadmap: [https://wiki.earthdata.nasa.gov/display/EDPUB/EDPub+Feature+Roadmap](https://wiki.earthdata.nasa.gov/display/EDPUB/EDPub+Feature+Roadmap)


### PR DESCRIPTION
## Description

I have updated the pull request and issue templates to try to make the issue / PR process a bit
more contributor / maintainer friendly

## Linked JIRA Task or Github Issue

JIRA Task: [EDPUB-1478](https://bugs.earthdata.nasa.gov/browse/EDPUB-1478)

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Test creating a new issue to see if issue templates are available.
3. Test creating a new PR to see if the pull request template is available
