### PR TITLE
Hotfix/remove daac id filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update MFA to EDPub custom flow
 - Updated github repo template assets
 - Updated the My Metrics Page to be a subpage of the Metrics Tab
+- Remove DAAC long name from request details page
 <!-- Unreleased changes can be added here. -->
 
 ## 1.0.19

--- a/app/src/js/components/Requests/request.js
+++ b/app/src/js/components/Requests/request.js
@@ -367,11 +367,6 @@ class RequestOverview extends React.Component {
         accessor: row => row.data_producer_name
       },
       {
-        label: 'Daac',
-        accessor: row => row.daac_name && canEdit ? <a href={`/daacs/selection?requestId=${row.id}`} aria-label="View daac selection">{row.daac_name}</a> : row.daac_name ? row.daac_name : row.daac_id,
-        classList: 'hidden'
-      },
-      {
         label: 'Initiator',
         accessor: row => row?.initiator?.name && canViewUsers ? <Link to={`/users/id/${row.initiator.id}`} aria-label="View request creator">{row.initiator.name}</Link> : null
       },


### PR DESCRIPTION
## Description

Accession request now begin without being assigned to a DAAC. This was causing issue with the request details API query because it assumed a DAAC was assigned in order to provide the DAAC long name. Because of this change and not really needing the DAAC long name even if the request is assigned, it is simplest just to remove this element from the dashboard.

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-api/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally (one in API and dashboard).
3. Sign into the dashboard.
4. Create a new accession request
5. Navigate to the request details page of the new accession request.
6. Confirm that the page loads with information related to the new accession request.
