### PR TITLE
Hotfix: Fix step comment newlines

### DIFF
--- a/app/src/js/components/Comments/comments.js
+++ b/app/src/js/components/Comments/comments.js
@@ -72,7 +72,7 @@ class Comment extends React.Component {
           const viewer_str = viewers && viewers.length ? `, Viewers: ${viewers.join(", ")}` : "";
 
           if (document.getElementById('previously-saved') !== null && typeof note !== 'undefined') {
-            document.getElementById('previously-saved').innerHTML += `${note}, From: ${author} ${viewer_str}<br>`;
+            document.getElementById('previously-saved').innerHTML += `${decodeURI(note)}, From: ${author} ${viewer_str}<br>`;
           }
         }
       });
@@ -114,7 +114,7 @@ class Comment extends React.Component {
     if (this.state.textRef.current.value !== '') {
       const date = new Date();
       const datetime = date.toLocaleString();
-      const comment = `${datetime} - ${this.state.textRef.current.value}`;
+      const comment = `${datetime} - ${encodeURI(this.state.textRef.current.value)}`;
       const reply = `${requestName} - Step: ${stepName}, Comment: ${comment}`;
       const resp = reply.replace(/[\n\t\r\'\"]/g, '\\$&');
       // if the user has chosen to specify viewers, ensure that they are one of them
@@ -265,7 +265,7 @@ class Comment extends React.Component {
           {typeof requestId !== 'undefined' &&
             <form className='flex__column flex__item--grow-1'
               onSubmit={(e) => { e.preventDefault(); this.reply(requestName, conversationId, stepName, step); }}>
-              <span id='previously-saved' style={{ padding: '0.3em 2em 0.4em 0.7em' }}></span>
+              <span id='previously-saved' style={{ padding: '0.3em 2em 0.4em 0.7em', whiteSpace: "pre-wrap"}}></span>
               {requestId !== '' && reviewable && sameFormAsStep
                 ? <><textarea placeholder='Enter a comment'
                   ref={this.state.textRef}

--- a/app/src/js/components/Comments/comments.js
+++ b/app/src/js/components/Comments/comments.js
@@ -116,7 +116,6 @@ class Comment extends React.Component {
       const datetime = date.toLocaleString();
       const comment = `${datetime} - ${encodeURI(this.state.textRef.current.value)}`;
       const reply = `${requestName} - Step: ${stepName}, Comment: ${comment}`;
-      const resp = reply.replace(/[\n\t\r\'\"]/g, '\\$&');
       // if the user has chosen to specify viewers, ensure that they are one of them
       const current_user = JSON.parse(window.localStorage.getItem('auth-user'));
       const viewer_user_list = [...this.state.commentViewers];
@@ -127,7 +126,7 @@ class Comment extends React.Component {
           viewerList.push(current_user.name);
         
       } 
-      const payload = { conversation_id: id, text: resp, step_name: step , viewer_users: viewer_user_list, viewer_roles: this.state.commentViewerRoles};
+      const payload = { conversation_id: id, text: reply, step_name: step , viewer_users: viewer_user_list, viewer_roles: this.state.commentViewerRoles};
       dispatch(replyConversation(payload));
       const author = current_user.name;
       const viewer_str = viewerList && viewerList.length ? `, Viewers: ${viewerList.join(", ")}` : "";


### PR DESCRIPTION
## Description

GES DISC reported a bug where the step comments entry would fail (error on API call) if the text contained newlines. This behavior is not the case for the conversations tab, so step comments text entry and display was updated to align with the conversations tab.

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new request.
4. Change the step to a form review step.
5. Add a comment like
```
Hello!

This is a test of using newlines.

Goodbye!
```
6. Send the comment. Ensure that the newlines are displayed as expected after send.
7. Refresh the page.
8. Ensure that the comment and newlines are displayed as expected.
