### PR TITLE
Hotfix: Include review manager as acceptable privileges for request review

### DIFF
--- a/app/src/js/utils/privileges.js
+++ b/app/src/js/utils/privileges.js
@@ -111,7 +111,7 @@ export const requestCanReview = (privileges, stepName) => {
     return privileges.REQUEST.includes("REVIEW_MANAGER");
   }
 
-  return privileges.REQUEST.includes("REVIEW");
+  return privileges.REQUEST.includes("REVIEW") || privileges.REQUEST.includes("REVIEW_MANAGER");
 }
 
 export const formPrivileges = (privileges) => {


### PR DESCRIPTION
## Description

Fixing bug where DAAC data manager is unable to review non manager review specific review step.

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new request
4. Move it to a form review step
5. Sign in as a data manager
6. Confirm the next action button for the form review step is green.
