### PR TITLE
Moving additional review required question to seperate page for routi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Updated the My Metrics Page to be a subpage of the Metrics Tab
 - Remove DAAC long name from request details page
 - Adding page for ESDIS final approval
+- Moved additional review question from DAAC Assignment prompt to seperate page
 <!-- Unreleased changes can be added here. -->
 
 ## 1.0.19

--- a/app/src/js/components/Requests/additional_review.js
+++ b/app/src/js/components/Requests/additional_review.js
@@ -1,0 +1,237 @@
+'use strict';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Link, withRouter } from 'react-router-dom';
+import {
+  getRequest,
+  setWorkflowStep,
+  promoteStep
+} from '../../actions';
+import {
+  lastUpdated,
+  shortDateShortTimeYearFirst
+} from '../../utils/format';
+import { requestPrivileges } from '../../utils/privileges';
+import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
+import Table from '../SortableTable/SortableTable';
+
+class AdditionalReviewQuestion extends React.Component {
+  constructor () {
+    super();
+    this.state = {
+      requiresReview: null,
+    };
+    this.displayName = 'Workflow Question';
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.navigateBack = this.navigateBack.bind(this);
+  }
+
+  componentDidMount () {
+    const search = this.props.location.search.split('=');
+    const requestId = search[1].replace(/&step/g, '');
+    const { dispatch } = this.props;
+    dispatch(getRequest(requestId));
+  }
+
+  async handleSubmit () {
+    // If the data requires additional scruitiny by the daac, just go to the next step in the workflow
+    // If it doesn't - re-route the workflow so that the submission ends up at final daac selection
+    const request = this.props.requests.detail.data;
+
+    if (this.state.requiresReview === false) {
+      const payload = {
+        id: request.id,
+        workflow_id: request.workflow_id,
+        step_name: 'esdis_final_review'
+      };
+      await this.props.dispatch(setWorkflowStep(payload));
+    }
+    await this.props.dispatch(promoteStep({ id: request.id }))
+      .then(() => {
+        this.props.history.push('/requests');
+      });
+  }
+
+  hasStepData () {
+    if (typeof this.props.requests !== 'undefined' &&
+      typeof this.props.requests.detail.data !== 'undefined' &&
+      typeof this.props.requests.detail.data.step_data !== 'undefined') {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  getFormalName (str) {
+    if (typeof str === 'undefined') return '';
+    const count = (str.match(/_/g) || []).length;
+    if (count > 0) {
+      str = str.replace(/_/g, ' ');
+    }
+    const words = str.split(' ');
+    for (let i = 0; i < words.length; i++) {
+      words[i] = words[i][0].toUpperCase() + words[i].substr(1);
+    }
+    return words.join(' ');
+  }
+
+  navigateBack () {
+    this.props.history.push('/requests');
+  }
+
+  setReviewState (reviewChoice) {
+    this.setState({ requiresReview: reviewChoice });
+  }
+
+  render () {
+    const search = this.props.location.search.split('=');
+    const requestId = search[1].replace(/&step/g, '');
+    const step = search[2];
+    const stepName = this.getFormalName(step);
+    const { canReview } = requestPrivileges(this.props.privileges, step);
+    let requestForms = [];
+    let showTable = false;
+    let request = '';
+    const verbage = ['Go back', 'Submit'];
+    if (this.hasStepData()) {
+      request = this.props.requests.detail.data;
+
+      if (this.props.requests.detail.data.forms !== null) {
+        requestForms = this.props.requests.detail.data.forms;
+        showTable = true;
+      }
+    }
+    const breadcrumbConfig = [
+      {
+        label: 'Dashboard Home',
+        href: '/'
+      },
+      {
+        label: 'Requests',
+        href: '/requests'
+      },
+      {
+        label: 'Question',
+        href: '/requests/question',
+        active: true
+      }
+    ];
+    const tableColumns = [
+      {
+        Header: 'Name',
+        accessor: row => <Link to={`/forms/id/${row.id}?requestId=${request.id}`} aria-label="View your form details">{row.long_name}</Link>,
+        id: 'long_name'
+      },
+      {
+        Header: 'Submitted at',
+        accessor: row => shortDateShortTimeYearFirst(row.submitted_at),
+        id: 'submitted_at'
+      }
+    ];
+
+    const infoSectionStyles = {
+      width: '100%',
+      textAlign: 'left',
+      marginTop: '16px',
+      wordWrap: 'break-word',
+      whiteSpace: 'normal',
+    };
+
+    const disabledButtonStyles = {
+      backgroundColor: '#cccccc',
+      color: '#666666',
+    };
+
+    const radioInputStyles = {
+      cursor: 'pointer',
+    };
+
+    const radioLabelStyles = {
+      display: 'flex',
+      alignItems: 'center',
+      marginRight: '15px',
+    };
+
+    return (
+      <div className='page__component'>
+        <section className='page__section page__section__controls'>
+          <Breadcrumbs config={breadcrumbConfig} />
+        </section>
+        <section className='page__section'>
+          <h1 className='heading--large heading--shared-content with-description width--three-quarters'>{requestId}</h1>
+          {request && lastUpdated(request.last_change, 'Updated')}
+        </section>
+        <section className='page__section'>
+          <div className='heading__wrapper--border'>
+            <h2 className='heading--medium with-description'><strong>Step</strong>:&nbsp;&nbsp;&nbsp;&nbsp;{stepName}</h2>
+          </div>
+        </section>
+        <section className='page__section'>
+          <div className="mt-3" style={infoSectionStyles}>
+            <h3>Does this data require additional review by a DAAC?</h3>
+          </div>
+          <div>
+            <label style={radioLabelStyles}>
+              <input type="radio" style={radioInputStyles} id="review_required_yes" onChange={() => this.setReviewState(true)} checked={this.state.requiresReview === true}/>
+              <label style={{ marginLeft: '5px', marginBottom: '0px', fontSize: '1em' }} htmlFor="review_required_yes">Yes</label>
+            </label>
+            <label style={radioLabelStyles}>
+              <input type="radio" style={radioInputStyles} id="review_required_no" onChange={() => this.setReviewState(false)} checked={this.state.requiresReview === false}/>
+              <label style={{ marginLeft: '5px', marginBottom: '0px', fontSize: '1em' }} htmlFor="review_required_no">No</label>
+            </label>
+          </div>
+        </section>
+        <br />
+        <br />
+        <section className='page__section'>
+          {showTable && typeof requestId !== 'undefined'
+            ? <>
+              <h2 className='heading--medium with-description heading__wrapper--border'>Request Forms</h2>
+              <Table
+                data={requestForms}
+                dispatch={this.props.dispatch}
+                tableColumns={tableColumns} /></>
+            : null}
+        </section>
+        {canReview && (
+        <section className='page__section'>
+          <div className='flex__row reject-approve'>
+            <div className='flex__item--spacing'>
+              <button onClick={() => this.navigateBack()}
+                className='button button--cancel button__animation--md button__arrow button__arrow--md button__animation button--secondary form-group__element--right'
+              > {verbage[0]}
+              </button>
+            </div>
+            <div className='flex__item--spacing'>
+              <button onClick={() => this.handleSubmit()}
+                className='button button--submit button__animation--md button__arrow button__arrow--md button__animation button__arrow--white form-group__element--right'
+                style={ this.state.requiresReview === null ? { ...disabledButtonStyles } : null }
+                disabled= { !(this.state.requiresReview !== null) }
+              > {verbage[1]}
+              </button>
+            </div>
+          </div>
+        </section>
+        )}
+      </div>
+    );
+  }
+}
+
+AdditionalReviewQuestion.propTypes = {
+  match: PropTypes.object,
+  dispatch: PropTypes.func,
+  requests: PropTypes.object,
+  logs: PropTypes.object,
+  history: PropTypes.object,
+  location: PropTypes.object,
+  privileges: PropTypes.object,
+  params: PropTypes.object
+};
+
+export default withRouter(connect(state => ({
+  requests: state.requests,
+  privileges: state.api.tokens.privileges,
+  logs: state.logs
+}))(AdditionalReviewQuestion));

--- a/app/src/js/components/Requests/index.js
+++ b/app/src/js/components/Requests/index.js
@@ -9,6 +9,7 @@ import InactiveRequestsOverview from './withdrawn';
 import ApprovalStep from './approval';
 import ActionRequestsOverview from './status';
 import EsdisApprovalStep from './esdis-approval';
+import AdditionalReviewQuestion from './additional_review';
 
 const Requests = ({
   location,
@@ -36,6 +37,7 @@ const Requests = ({
               <Route path='/requests/approval/esdis' component={EsdisApprovalStep} />
               <Route path='/requests/approval' component={ApprovalStep} />
               <Route path='/requests/status' component={ActionRequestsOverview} />
+              <Route path='/requests/question' component={AdditionalReviewQuestion} />
             </Switch>
           </div>
         </div>

--- a/app/src/js/utils/privileges.js
+++ b/app/src/js/utils/privileges.js
@@ -112,14 +112,13 @@ export const requestPrivileges = (privileges, stepName) => {
 export const requestCanReview = (privileges, stepName) => {
   if (stepName && stepName.match(/management_review/g)) {
     return privileges.REQUEST.includes("REVIEW_MANAGER");
-  }
-  else if (stepName && stepName.match(/esdis_final_review/g)) {
+  } else if (stepName && (stepName.match(/esdis_final_review/g) || stepName.match(/additional_review_question/g))) {
     const user = JSON.parse(window.localStorage.getItem('auth-user'));
     return privileges.REQUEST.includes('REVIEW_ESDIS') && user.user_groups.some((group) => group.short_name === 'root_group');
   }
 
   return privileges.REQUEST.includes("REVIEW") || privileges.REQUEST.includes("REVIEW_MANAGER");
-}
+};
 
 export const formPrivileges = (privileges) => {
   if (privileges.ADMIN) {

--- a/app/src/js/utils/table-config/requests.js
+++ b/app/src/js/utils/table-config/requests.js
@@ -118,6 +118,8 @@ export const esdisReviewLink = (row, formalName, step) => {
     return <Link to={'#'} className={'button button--medium button--clear form-group__element--left button--no-icon assign-workflow'} aria-label={formalName}>{formalName}</Link>;
   } else if (disabled) {
     return formalName;
+  } else if (step === 'additional_review_question') {
+    return <Link to={`/requests/question?requestId=${row.id}&step=${step}`} className={'button button--medium button--green form-group__element--left button--no-icon next-action'} aria-label={formalName || 'review item'}>{formalName}</Link>;
   } else {
     return <Link to={`/requests/approval/esdis?requestId=${row.id}&step=${step}`} className={'button button--medium button--green form-group__element--left button--no-icon next-action'} aria-label={formalName || 'review item'}>{formalName}</Link>;
   }
@@ -220,6 +222,8 @@ export const stepLookup = (row) => {
     return assignWorkflow(request, formalName);
   } else if (stepType.match(/action/g) && stepName.match(/daac_assignment(_final)?/g)) {
     return assignDaacs(request, formalName);
+  } else if (stepName.match(/additional_review_question/g)){
+    return esdisReviewLink(row, formalName, stepName);
   } else if (stepType.match(/action/g) ||  stepType.match(/upload/g)) {
     return existingLink(row, undefined, formalName, stepName, stepType);
   } else if (stepType.match(/review/g) && stepName.match(/esdis_final_review/g)) {


### PR DESCRIPTION
…ng ease

## Description

A question for indicating whether a submission required additional scrutiny by a DAAC was added to the DAAC Assignment prompt in #132. During work on the backend changes to handle the additional question it was determined that moving this question to its own page would simplify conditional routing. This PR removes the question from the DAAC Assignment prompt and moves it to its own page

## Linked JIRA Task or Github Issue

Related JIRA Tasks: 
- https://bugs.earthdata.nasa.gov/browse/EDPUB-1499
- https://bugs.earthdata.nasa.gov/browse/EDPUB-1497

Backend Requirement:
- https://github.com/eosdis-nasa/earthdata-pub-api/pull/220

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

_This will help us get a jump start on validating your PR by describing the steps to replicate
and validate the expected behavior. (For an example of good validation instructions, check out [Bryan's Bouncy Ball PR.](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701))_

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new submission
4. Move the submission to the Additional Review Question step
5. Select `yes` and submit
6. Verify that the next step is DAAC Assignment
7. Move the submission back to the Additional Review Question step
8. Select `no` and submit
9. Verify that the next step is DAAC Assignment Final

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...

I briefly considered making the question page more generic by populating it dynamically like we do form questions so that it was extensible for other potential questions in the future. I chose this route because it was significantly faster to implement and because the future planned work to look into being able to handle more complex workflows may make separate question pages like this unnecessary.