### PR TITLE
Edpub 1505: Investigate Conversations Error

### DIFF
--- a/app/src/js/components/Conversations/conversation.js
+++ b/app/src/js/components/Conversations/conversation.js
@@ -222,21 +222,21 @@ const checkForUpdates = async (retryCount = 0) => {
     setShouldStopRetries(false);
 
     if ([...uploadedFiles].length > 0) {
-        const tempNote = {
-            id: `temp-${Date.now()}`,
-            sent: new Date().toISOString(),
-            text: resp,
-            createdAt: new Date().toISOString(),
-            attachments: [...uploadedFiles],
-            viewers: { roles: [], users: [] },
-            isTemp: true 
-        };
-        setTempNotes(prev => [tempNote, ...prev]);
-        setDisplayNotes(prev => [tempNote, ...prev]);
-        checkForUpdates(0);
+      const tempNote = {
+          id: `temp-${Date.now()}`,
+          sent: new Date().toISOString(),
+          text: resp,
+          createdAt: new Date().toISOString(),
+          attachments: [...uploadedFiles],
+          viewers: { roles: [], users: [] },
+          isTemp: true 
+      };
+      setTempNotes(prev => [tempNote, ...prev]);
+      setDisplayNotes(prev => [tempNote, ...prev]);
+      checkForUpdates(0);
     }else{
-        setTempNotes(prev => [...prev]);
-        setDisplayNotes(prev => [...prev]);
+      setTempNotes(prev => [...(prev || [])]);
+      setDisplayNotes(prev => [...(prev || [])]);      
     }
 
     if (textRef.current) {


### PR DESCRIPTION
## Description
During testing, Chelsey found that request conversations are occasionally encountering an error while loading. This appears to be caused by the use of state variables and useEffect changing the state variable effectively creating an infinite loop. The task will likely need to update how useEffect is being used in this code block to resolve the issue.

https://eosdis.slack.com/archives/C01JY5B73QC/p1741032198716899




## Linked JIRA Task or Github Issue

JIRA Task:[ [example](link_here)](https://bugs.earthdata.nasa.gov/browse/EDPUB-1505)

Github Issue: [example](link_here)

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

_This will help us get a jump start on validating your PR by describing the steps to replicate
and validate the expected behavior. (For an example of good validation instructions, check out [Bryan's Bouncy Ball PR.](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701))_

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Steps to reproduce gathered from the above thread:

Deploy the develop branch locally.
Sign in as Earthdata Pub System user.
Create a new request.
Open Chrome dev tools.
Go to the request's conversation page.
Validate the following error in the console:
Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
Occasionally, this may also result in the attached error being displayed in the dashboard.

**You should not see the warning now**