### PR TITLE
EDPUB-1533: Add delete not yet uploaded file feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update MFA to EDPub custom flow
 - Updated github repo template assets
 - Updated the My Metrics Page to be a subpage of the Metrics Tab
+- Added the ability to remove not yet uploaded files from upload list
 <!-- Unreleased changes can be added here. -->
 
 ## 1.0.19

--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -29,7 +29,6 @@ class UploadOverview extends React.Component {
       statusMsg: 'Select a file', 
       uploadFile: '', 
       keys: [],
-      showProgressBar: false, // Added state to control the visibility of the progress bar,
       progressValue: 0, // Initialize progressValue,
       uploadFailed: false,
       uploadFileName: '',
@@ -38,12 +37,11 @@ class UploadOverview extends React.Component {
       categoryType: null,
       uploadFiles: [],
       uploadStatusMsg: '',
-      showProgressBar: false,
       uploadFileFlag: false,
       showUploadSummaryModal: false,
       uploadResults: {},
       uploadProgress: {},
-      progressBarsVisible: false
+      progressBarsVisible: true
     };
     this.handleClick = this.handleClick.bind(this);
     this.handleChange = this.handleChange.bind(this);
@@ -182,9 +180,7 @@ class UploadOverview extends React.Component {
 
   async handleUpload() {
     this.setState({
-      uploadStatusMsg: 'Uploading...',
-      showProgressBar: true,
-      progressBarsVisible: true
+      uploadStatusMsg: 'Uploading...'
     });
   
     const successFiles = [];
@@ -264,11 +260,11 @@ class UploadOverview extends React.Component {
   
     this.setState({
       uploadStatusMsg: '',
-      showProgressBar: false,
       uploadFileFlag: true,
       showUploadSummaryModal: true,
       uploadFiles: [],
-      uploadResults: { success: successFiles, failed: failedFiles }
+      uploadResults: { success: successFiles, failed: failedFiles },
+      uploadProgress: {}
     });
     this.getFileList()
   }
@@ -279,6 +275,10 @@ class UploadOverview extends React.Component {
 
   toggleProgressBars = () => {
     this.setState({ progressBarsVisible: !this.state.progressBarsVisible });
+  };
+
+  handleRemoveFile = (fileName) => {
+    this.setState({uploadFiles: this.state.uploadFiles.filter(elem => elem.name !== fileName)});
   };
 
   async componentDidUpdate(prevProps){
@@ -400,7 +400,7 @@ class UploadOverview extends React.Component {
                 </>
                 : null
               }
-              {this.state.showProgressBar && this.state.progressValue > 0 && 
+              {this.state.progressValue > 0 &&
                 <div style={progressBarStyle}>
                   <div style={progressBarFillStyle}>
                     <span style={numberDisplayStyle}>{this.state.uploadFailed ? <span>{'Upload Failed'}<span className="info-icon" data-tooltip={this.state.error}></span></span>: `${this.state.progressValue}%`}</span>
@@ -460,8 +460,8 @@ class UploadOverview extends React.Component {
                   )}                                            
                 </div>
               </div>
-              <button onClick={(e) => this.handleClick(e)} className={`upload-button upload-button-category mt-2 button button__animation--md button__arrow button__arrow--md button__animation button__arrow--white ${(this.state.categoryType || groupId) && !this.state.showProgressBar? 'button--submit' : 'button--secondary button--disabled'}`}>{this.state.uploadStatusMsg === ''? 'Upload': 'Uploading...'}</button>
-              {this.state.showProgressBar && <span className="d-flex align-items-center">
+              <button onClick={(e) => this.handleClick(e)} className={`upload-button upload-button-category mt-2 button button__animation--md button__arrow button__arrow--md button__animation button__arrow--white ${(this.state.categoryType || groupId) && this.state.uploadFiles.length !== 0? 'button--submit' : 'button--secondary button--disabled'}`}>{this.state.uploadStatusMsg === ''? 'Upload': 'Uploading...'}</button>
+              {<span className="d-flex align-items-center">
                 <FontAwesomeIcon
                   icon={progressBarsVisible ? faEyeSlash : faEye}
                   style={{ cursor: 'pointer', marginLeft: '10px', fontSize: '20px' }}
@@ -475,7 +475,22 @@ class UploadOverview extends React.Component {
                 <div>
                   {this.state.uploadFiles.map((file, index) => (
                     <div key={index}>
-                      <p>{file.name}</p>
+                      <div style={{display: "flow-root"}}>
+                        {file.name}
+                        <Button
+                          style={{
+                            fontSize: "100%",
+                            padding: "5px",
+                            backgroundColor: "#db1400",
+                            margin: "2px",
+                            float: "inline-end",
+                            border: "none",
+                            borderRadius: "4px",
+                            color: "white",
+                          }}
+                          onClick={() => this.handleRemoveFile(file.name)}
+                          >Remove</Button>
+                      </div>
                       <div style={{ width: '100%', backgroundColor: uploadProgress[file.name] !== 'Failed'?'#f1f1f1':'red', height: '30px', marginBottom: '5px' }}>
                         <div style={{
                           width: `${uploadProgress[file.name] || 0}%`,

--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -14,6 +14,8 @@ import { shortDateShortTimeYearFirstJustValue, storage } from '../../utils/forma
 import Table from '../SortableTable/SortableTable';
 import { Modal, Button } from 'react-bootstrap';
 
+// Request Details Overview Page i.e. /dashboard/requests/id/{id}
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/app/src/js/components/FormQuestions/FormQuestions.css
+++ b/app/src/js/components/FormQuestions/FormQuestions.css
@@ -747,7 +747,6 @@
 
 .questions-component .question_section {
   margin-top: 20px;
-  cursor: pointer;
 }
 
 .questions-component .date_formats {

--- a/app/src/js/components/FormQuestions/questions.js
+++ b/app/src/js/components/FormQuestions/questions.js
@@ -19,6 +19,8 @@ import _config from '../../config';
 import localUpload from '@edpub/upload-utility';
 import { format } from "date-fns";
 
+// Form page i.e. /dashboard/form/questions/{id}
+
 const FormQuestions = ({
   cancelLabel = 'Cancel',
   draftLabel = 'Save as draft',
@@ -46,7 +48,6 @@ const FormQuestions = ({
   const [uploadedFiles, setUploadedFiles] = useState({});
   const [validationAttempted, setValidationAttempted] = useState(false);
   const [progressValue, setProgressValue] = useState(0);
-  const [showProgressBar, setShowProgressBar] = useState(false);
   const [uploadFileName, setUploadFileName] = useState('');
   const [uploadFileFlag, setUploadFileFlag] = useState(false);
   const [uploadFailed, setUploadFailed] = useState(false);
@@ -1046,7 +1047,7 @@ const FormQuestions = ({
   const { apiRoot } = _config;
   const [uploadResults, setUploadResults] = useState({ success: [], failed: [] });
   const [showUploadSummaryModal, setShowUploadSummaryModal] = useState(false);
-  const [progressBarsVisible, setProgressBarsVisible] = useState(false); 
+  const [progressBarsVisible, setProgressBarsVisible] = useState(true);
   const [uploadProgress, setUploadProgress] = useState({});
 
   const category_map = {
@@ -1056,8 +1057,6 @@ const FormQuestions = ({
 
   const handleUpload = async (control_id) => {
     setUploadStatusMsg('Uploading...');
-    setShowProgressBar(true);
-    setProgressBarsVisible(true);
     const successFiles = [];
     const failedFiles = [];
 
@@ -1115,8 +1114,6 @@ const FormQuestions = ({
 
     setUploadResults({ success: successFiles, failed: failedFiles });
     setUploadStatusMsg('Upload Complete');
-    setShowProgressBar(false);
-    setProgressBarsVisible(false);
     setUploadProgress({});
     setUploadFileFlag(true);
     setShowUploadSummaryModal(true);
@@ -1262,6 +1259,10 @@ const FormQuestions = ({
         return { ...updatedValues, validation_errors: newValidationErrors };
       });
     }
+  };
+
+  const handleRemoveFile = (fileName) => {
+    setUploadFiles(uploadFiles.filter(elem => elem.name !== fileName));
   };
 
   return !requestData ? (
@@ -2239,11 +2240,11 @@ const FormQuestions = ({
                                           <Button
                                             className="upload-button mt-2"
                                             onClick={(e) => handleUpload(input.control_id)}
-                                            disabled={uploadFiles.length === 0 || showProgressBar || `${fileControlId}_file-upload-input` !== `${input.control_id}_file-upload-input`}
+                                            disabled={uploadFiles.length === 0 || `${fileControlId}_file-upload-input` !== `${input.control_id}_file-upload-input`}
                                           >
                                           Upload
                                           </Button>
-                                          {showProgressBar && 
+                                          {
                                           <span className="d-flex align-items-center">
                                             <FontAwesomeIcon
                                               icon={progressBarsVisible ? faEyeSlash : faEye}
@@ -2258,7 +2259,14 @@ const FormQuestions = ({
                                             <div>
                                               {uploadFiles.map((file, index) => (
                                                 <div key={index}>
-                                                  <p>{file.name}</p>
+                                                  <div style={{display: "flow-root"}}>
+                                                    {file.name}
+                                                    <Button
+                                                      className="upload-button"
+                                                      style={{fontSize: "100%", padding: "5px", backgroundColor: "#db1400", margin: "2px", float: "inline-end"}}
+                                                      onClick={() => handleRemoveFile(file.name)}
+                                                      >Remove</Button>
+                                                  </div>
                                                   <div style={{ width: '100%', backgroundColor: uploadProgress[file.name] !== 'Failed'?'#f1f1f1':'red', height: '30px', marginBottom: '5px' }}>
                                                     <div style={{
                                                       width: `${uploadProgress[file.name] || 0}%`,


### PR DESCRIPTION
## Description

Added the ability to remove not yet uploaded files from file list. This allows a user to avoid uploading a file which may have been selected on accident.

## Linked JIRA Task

JIRA Task: https://bugs.earthdata.nasa.gov/browse/EDPUB-1533

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [x] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Push the related branches to SIT.
3. Go to a request's detail overview page.
4. Select a couple files to upload.
5. Validate that you will now see each file's progress bars by default.
6. Validate that you see a red `Remove` button on the right side.
7. Try removing a couple of the selected files.
8. With at least one file still selected, click the `Upload` button. (Be sure to click a category for the files to be uploaded to)
9. Validate that only the still selected file(s) was uploaded.
10. Navigate to an accession form.
11. Validate steps 4-9 in each of the upload modules again.