### PR TITLE
EDPUB-1513: Stop Querying API with undefined formId

### DIFF
--- a/app/src/js/components/Comments/comments.js
+++ b/app/src/js/components/Comments/comments.js
@@ -25,7 +25,8 @@ class Comment extends React.Component {
       searchType: 'user', 
       commentViewers: [], 
       commentViewerRoles: [],
-      idMap: {} 
+      idMap: {} ,
+      formsMap: {}
     };
 
     this.openSearch = this.openSearch.bind(this);
@@ -44,14 +45,18 @@ class Comment extends React.Component {
     const { dispatch } = this.props;
     const { formId } = this.props.match.params;
     await dispatch(getRequest(requestId));
-    await dispatch(getForm(formId, this.props.requests.detail.data.daac_id));
-    let reviewStepName = `${this.props.forms.map[formId].data.short_name}_form_review`;
+    if (formId) {
+      await dispatch(getForm(formId, this.props.requests.detail.data.daac_id));
+      this.setState({formsMap: this.props.forms.map});
+    } else {this.setState({formsMap: {'undefined': {data: {error: 'No formId'}}}});}
+    const formObj = this.state.formsMap[formId];
+    let reviewStepName = `${formObj.data.short_name}_form_review`;
     if (this.props.requests.detail.data.conversation_id) {
       if ( typeof this.props.requests.detail.data.step_name !== 'undefined' && typeof step === 'undefined'){
         reviewStepName = this.props.requests.detail.data.step_name;
-      } else if (typeof this.props.forms.map[formId].data.short_name === 'undefined' && typeof step !== 'undefined') {
+      } else if (typeof formObj.data.short_name === 'undefined' && typeof step !== 'undefined') {
         reviewStepName = step;
-      } else if (typeof this.props.forms.map[formId].data.short_name === 'undefined') {
+      } else if (typeof formObj.data.short_name === 'undefined') {
         reviewStepName = '';
       }
       const payload = { conversation_id: this.props.requests.detail.data.conversation_id, level: true, step_name: reviewStepName };
@@ -221,8 +226,8 @@ class Comment extends React.Component {
       }
     };
     if (this.hasStepData() && request !== undefined) {
-      if (this.props.forms.map !== undefined && this.props.forms.map[formId] !== undefined && this.props.forms.map[formId].data !== undefined) {
-        formName = this.props.forms.map[formId].data.short_name;
+      if(this.state.formsMap[formId]?.data !== undefined) {
+        formName = this.state.formsMap[formId]?.data?.short_name;
         if (this.props.requests.detail.data.forms !== null) {
           if (this.props.requests.detail.data.form_data?.data_product_name_value) {
             requestName = this.props.requests.detail.data.form_data.data_product_name_value;

--- a/app/src/js/components/Comments/comments.js
+++ b/app/src/js/components/Comments/comments.js
@@ -49,6 +49,7 @@ class Comment extends React.Component {
       await dispatch(getForm(formId, this.props.requests.detail.data.daac_id));
       this.setState({formsMap: this.props.forms.map});
     } else {this.setState({formsMap: {'undefined': {data: {error: 'No formId'}}}});}
+    // TODO - Update the above line to properly handle this error rather than just matching existing functionality
     const formObj = this.state.formsMap[formId];
     let reviewStepName = `${formObj.data.short_name}_form_review`;
     if (this.props.requests.detail.data.conversation_id) {


### PR DESCRIPTION
## Description

Dashboard was querying API with undefined formId. This would lead to an error mapping to the formId map. To maintain existing functionality, I replicated this erroneous mapping. In the future, we should investigate properly handling this error and display.

## Linked JIRA Task or Github Issue

JIRA Task: [EDPUB-1513](https://bugs.earthdata.nasa.gov/browse/EDPUB-1513)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new request.
4. Create a user with observer role and root group.
5. Move the request to the ESDIS Final Review Step.
6. Open chrome dev tools
7. Navigate to the ESDIS Final Review Step page.
8. Validate that an API call with an undefined formId is not sent.
