### PR TITLE
Observer role should have review permissions

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,8 +4,8 @@ version: v1.25.1
 ignore:
   SNYK-JS-ELLIPTIC-8187303:
     - '*':
-        reason: Waiting for package maintainers to update (https://github.com/indutny/elliptic/issues/331)
-        expires: 2025-05-18T17:58:48.024Z
+        reason: Waiting for package maintainers to update (https://github.com/indutny/elliptic/issues/331). May eventually be able to replace with something like https://github.com/paulmillr/noble-curves
+        expires: 2025-06-18T17:58:48.024Z
         created: 2025-03-18T17:58:48.026Z
-        # Updated 4/18/25
+        # Updated monthly: 4/18/25 - 5/19/25
 patch: {}

--- a/app/src/js/components/Review/review.js
+++ b/app/src/js/components/Review/review.js
@@ -74,7 +74,7 @@ class ReviewStep extends React.Component {
     const role = roles ? Object.keys(roles).map(role => roles[role].short_name) : [];
     const reviewers = this.props.rawReviewers.data
       .filter(reviewer => this.props.requests.detail.data.step_data.name === reviewer.step_name);
-    return reviewers.some(reviewer => reviewer.name === this.props.user) || (reviewers.length === 0 && role.some((userRole) => userRole !== 'observer'));
+    return reviewers.some(reviewer => reviewer.name === this.props.user) || reviewers.length === 0;
   }
 
   render() {


### PR DESCRIPTION
## Description

Observer role should have the permissions for reviewing outlined in https://wiki.earthdata.nasa.gov/display/EDPUB/EDPub+User+Groups+and+Roles 
Bug discovered when demoing to Info team- root group observer unable to approve DAR form.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new request.
4. Change the current step to the DAR review step.
5. Sign in as a root group observer.
6. Navigate to the DAR review page.
7. Confirm you can see the Approve / Return buttons