### PR TITLE
EDPUB-1580: Update downloaded form file name to be derived from request name

### DIFF
--- a/app/src/js/components/Requests/request.js
+++ b/app/src/js/components/Requests/request.js
@@ -187,10 +187,14 @@ class RequestOverview extends React.Component {
     const { requestId } = this.props.match.params;
     const updatedMetadata = await this.props.dispatch(metadataMapper(requestId)); 
     const mappedData = updatedMetadata.data ? JSON.stringify(updatedMetadata.data): "";
+    const fileName = this.props.requests.detail.data?.data_product_name ||
+      (this.props.requests.detail.data?.initiator?.name
+        ? 'Request Initialized by ' + this.props.requests.detail.data.initiator.name
+    : requestId);
     const a = document.createElement('a');
     const file = new Blob([mappedData], { type: 'application/json' });
     a.href = URL.createObjectURL(file);
-    a.download = `${this.props.requests.detail.data.id}`;
+    a.download = `${fileName}`;
     a.click();
   }
 


### PR DESCRIPTION
## Description

Update dashboard code to name to file downloaded for a metadata export to be derived from the request name.

## Linked JIRA Task or Github Issue

JIRA Task: [EDPUB-1580](https://bugs.earthdata.nasa.gov/browse/EDPUB-1580)

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

_This will help us get a jump start on validating your PR by describing the steps to replicate
and validate the expected behavior. (For an example of good validation instructions, check out [Bryan's Bouncy Ball PR.](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701))_

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Navigate to form review and the downloaded file names are derived from the request name where possible
