### PR TITLE
Hotfix: Update step name after rename in api

### DIFF
--- a/app/src/js/utils/privileges.js
+++ b/app/src/js/utils/privileges.js
@@ -113,7 +113,7 @@ export const requestPrivileges = (privileges, stepName) => {
 export const requestCanReview = (privileges, stepName, user) => {
   if (stepName && stepName.match(/management_review/g)) {
     return privileges.REQUEST.includes("REVIEW_MANAGER");
-  } else if (stepName && (stepName.match(/esdis_final_review/g) || stepName.match(/additional_review_question/g))) {
+  } else if (stepName && (stepName.match(/esdis_final_review/g) || stepName.match(/esdis_additional_review_assessment/g))) {
     return privileges.REQUEST.includes('REVIEW_ESDIS') && user.user_groups.some((group) => group.short_name === 'root_group');
   }
 

--- a/app/src/js/utils/table-config/requests.js
+++ b/app/src/js/utils/table-config/requests.js
@@ -120,7 +120,7 @@ export const esdisReviewLink = (row, formalName, step) => {
     return <Link to={'#'} className={'button button--medium button--clear form-group__element--left button--no-icon assign-workflow'} aria-label={formalName}>{formalName}</Link>;
   } else if (disabled) {
     return formalName;
-  } else if (step === 'additional_review_question') {
+  } else if (step === 'esdis_additional_review_assessment') {
     return <Link to={`/requests/question?requestId=${row.id}&step=${step}`} className={'button button--medium button--green form-group__element--left button--no-icon next-action'} aria-label={formalName || 'review item'}>{formalName}</Link>;
   } else {
     return <Link to={`/requests/approval/esdis?requestId=${row.id}&step=${step}`} className={'button button--medium button--green form-group__element--left button--no-icon next-action'} aria-label={formalName || 'review item'}>{formalName}</Link>;
@@ -233,7 +233,7 @@ export const stepLookup = (row) => {
     return assignWorkflow(request, formalName);
   } else if (stepType?.match(/action/g) && stepName?.match(/daac_assignment(_final)?/g)) {
     return assignDaacs(request, formalName);
-  } else if (stepName?.match(/additional_review_question/g)) {
+  } else if (stepName?.match(/esdis_additional_review_assessment/g)) {
     return esdisReviewLink(row, formalName, stepName);
   } else if (stepType?.match(/action/g) || stepType?.match(/upload/g)) {
     return existingLink(row, undefined, formalName, stepName, stepType);


### PR DESCRIPTION
## Description

Chelsey reported an error where the dashboard was missed during the esdis additional review step rename. This is just a hotfix to find/replace those references

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create new request
4. Move request ahead to the ESDIS Additional Review Assessment Step
5. Navigate to the step page
6. User should be presented with an option to select whether the dataset needs additional review or not