### PR TITLE
Hotfix: Fix download url query

### DIFF
--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -197,7 +197,7 @@ export const listFileDownloadsByKey = (key) => ({
     type: types.UPLOAD,
     method: 'GET',
     id: key,
-    path: `data/upload/downloadUrl/${key}`
+    path: `data/upload/downloadUrl?key=${key}`
   }
 });
 

--- a/app/src/js/components/DataUpload/overview.js
+++ b/app/src/js/components/DataUpload/overview.js
@@ -66,16 +66,12 @@ class UploadOverview extends React.Component {
       if (requestId !== '' && requestId != undefined && requestId !== null) {
         const download = new localUpload();
         const { apiRoot } = _config;
-        dispatch(listFileDownloadsByKey(this.state.keys[fileName], requestId))
-          .then(() => {
-            download.downloadFile(this.state.keys[fileName], `${apiRoot}data/upload/downloadUrl`, loadToken().token).then((resp) => {
-              let error = resp?.data?.error || resp?.error || resp?.data?.[0]?.error
-              if (error) {
-                console.log(`An error has occurred: ${error}.`);
-              }
-            })
+        download.downloadFile(this.state.keys[fileName], `${apiRoot}data/upload/downloadUrl`, loadToken().token).then((resp) => {
+          let error = resp?.data?.error || resp?.error || resp?.data?.[0]?.error
+          if (error) {
+            console.log(`An error has occurred: ${error}.`);
           }
-        );
+        })
       }
     }
   };

--- a/app/src/js/components/FormRequest/form.js
+++ b/app/src/js/components/FormRequest/form.js
@@ -282,16 +282,12 @@ class FormOverview extends React.Component {
       if (requestId !== '' && requestId != undefined && requestId !== null) {
         const download = new localUpload();
         const { apiRoot } = _config;
-        dispatch(listFileDownloadsByKey(this.state.keys[fileName], requestId))
-          .then(() => {
-            download.downloadFile(this.state.keys[fileName], `${apiRoot}data/upload/downloadUrl`, loadToken().token).then((resp) => {
-              let error = resp?.data?.error || resp?.error || resp?.data?.[0]?.error
-              if (error) {
-                console.log(`An error has occurred: ${error}.`);
-              }
-            })
+        download.downloadFile(this.state.keys[fileName], `${apiRoot}data/upload/downloadUrl`, loadToken().token).then((resp) => {
+          let error = resp?.data?.error || resp?.error || resp?.data?.[0]?.error
+          if (error) {
+            console.log(`An error has occurred: ${error}.`);
           }
-        );
+        })
       }
     }
   };

--- a/app/src/js/components/Forms/form.js
+++ b/app/src/js/components/Forms/form.js
@@ -315,16 +315,12 @@ class FormOverview extends React.Component {
       if (requestId !== '' && requestId != undefined && requestId !== null) {
         const download = new localUpload();
         const { apiRoot } = _config;
-        dispatch(listFileDownloadsByKey(this.state.keys[fileName], requestId))
-          .then(() => {
-            download.downloadFile(this.state.keys[fileName], `${apiRoot}data/upload/downloadUrl`, loadToken().token).then((resp) => {
-              let error = resp?.data?.error || resp?.error || resp?.data?.[0]?.error
-              if (error) {
-                console.log(`An error has occurred: ${error}.`);
-              }
-            })
+        download.downloadFile(this.state.keys[fileName], `${apiRoot}data/upload/downloadUrl`, loadToken().token).then((resp) => {
+          let error = resp?.data?.error || resp?.error || resp?.data?.[0]?.error
+          if (error) {
+            console.log(`An error has occurred: ${error}.`);
           }
-        );
+        })
       }
     }
   };


### PR DESCRIPTION
## Description

GES DISC reported an issue with downloading files which upon further investigation is the result of the file location changing due to the reroute feature updates. Upon further investigation, I found we were incorrectly concatenating the file key to the url rather than adding it as a querystring. I also found that we were making an unnecessary call to the downloadUrl endpoint.

## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Push the changes to SIT.
3. Open the network tab and attempt to download a file.
4. Verify that the file key is sent as a query string rather than concatenated to the request url.
5. Verify that only one request is sent to the downloadUrl endpoint (one is also sent to the AWS S3 download endpoint, but we're only interested that two same requests aren't sent to the EDPub maintained downloadUrl endpoint).