### PR TITLE
Hotfix: Update edpub upload utility version to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.19",
       "license": "BSD 3-Clause License",
       "dependencies": {
-        "@edpub/upload-utility": "^1.1.0",
+        "@edpub/upload-utility": "^1.1.1",
         "@floating-ui/utils": "^0.2.5",
         "@fortawesome/fontawesome-free": "^5.15.4",
         "@fortawesome/fontawesome-svg-core": "^1.2.32",
@@ -1910,13 +1910,13 @@
       }
     },
     "node_modules/@edpub/upload-utility": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@edpub/upload-utility/-/upload-utility-1.1.0.tgz",
-      "integrity": "sha512-bA7zZb6ndya5560pL6ZP3DBjn/N7K+j3ToVYRV4/5C1DajS1R+HSefYuZbtWxuZpIhu3Vi/wQ3O7KISsXNuuUA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@edpub/upload-utility/-/upload-utility-1.1.1.tgz",
+      "integrity": "sha512-goMVaviLvv4xr2ncU5zFOWc/So47M4mCy+EzWizqVRHA0q8LsHI56QCLl4LwSLTX9YuYaoIa+C5L5/Jn6q6F6g==",
       "license": "BSD 3-Clause License",
       "dependencies": {
         "file-saver": "^2.0.5",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "hash-wasm": "^4.9.0",
         "mime-types": "^2.1.35"
       }
@@ -9683,14 +9683,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
-    "@edpub/upload-utility": "^1.1.0",
+    "@edpub/upload-utility": "^1.1.1",
     "@floating-ui/utils": "^0.2.5",
     "@fortawesome/fontawesome-free": "^5.15.4",
     "@fortawesome/fontawesome-svg-core": "^1.2.32",


### PR DESCRIPTION
## Description

Update EDPub upload utility version to latest to avoid issues with vulnerable sub dependency.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Validate that the Snyk blocking step completes successfully
