### PR TITLE
Hotfix: Update submission -> accession rename

### DIFF
--- a/app/src/js/components/FormQuestions/questions.js
+++ b/app/src/js/components/FormQuestions/questions.js
@@ -1552,7 +1552,7 @@ const FormQuestions = ({
                               <span className="checkmark"></span>
                             </label>
                           )}
-                          {question.long_name === 'Data Submission Point of Contact' && (
+                          {question.long_name === 'Data Accession Point of Contact' && (
                             <label className="checkbox-item">
                               Same as Principal Investigator
                               <input


### PR DESCRIPTION
## Description

There is a bug where the `Same as Principal Investigator` option was not being displayed on the DAR form because the question had been renamed in the API.

What types of changes does your code introduce to Earthdata Pub (EDPub)?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Start a new accession request.
4. Validate that you see the checkbox saying `Same as Principal Investigator` in the `Data Accession Point of Contact` question