### PR TITLE
Updating textareas to display all content on initial render

### DIFF
--- a/app/src/js/components/FormQuestions/DynamicTable.js
+++ b/app/src/js/components/FormQuestions/DynamicTable.js
@@ -488,6 +488,7 @@ const DynamicTable = ({
                   onChange={(e) =>
                     setFormData({ ...formData, data_prod_comments: e.target.value })
                   }
+                  style={{ fieldSizing: 'content'}}
                 />
               </Form.Group>
             </div>

--- a/app/src/js/components/FormQuestions/questions.js
+++ b/app/src/js/components/FormQuestions/questions.js
@@ -2277,7 +2277,7 @@ const handleEnterKey = (event) => {
                                                 ? 'required'
                                                 : ''
                                             }
-                                            style={{ overflow: 'hidden' }}
+                                            style={{ overflow: 'hidden', fieldSizing: 'content' }}
                                             onChange={(e) => {
                                               handleFieldChange(
                                                 input.control_id,


### PR DESCRIPTION
## Description

When adding a large amount of content to a part of the form that was a text area, the area would elongate automatically while typing the new content. When the page was refreshed or first loaded however, the initial display was a set size and if the text was typed in such a way the user could potentially have no idea that there was additional text in the box outside of what fit in the default size.

This PR updates the form to display all the text in these fields.

## Linked JIRA Task or Github Issue

JIRA Task: [EDPUB-1750](https://bugs.earthdata.nasa.gov/browse/EDPUB-1750)


## Types of changes

What types of changes does your code introduce to Earthdata Pub (EDPub)?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if adding or updating the existing documentation resources)
- [ ] Other (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [Contributing Guide](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CONTRIBUTING.md)
- [ ] I have updated the [CHANGELOG](https://github.com/eosdis-nasa/earthdata-pub-dashboard/blob/main/CHANGELOG.md)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Validation Steps

_This will help us get a jump start on validating your PR by describing the steps to replicate
and validate the expected behavior. (For an example of good validation instructions, check out [Bryan's Bouncy Ball PR.](https://github.com/sparkbox/bouncy-ball/pull/56#issue-192153701))_

1. Make sure all merge request checks have passed (CI/CD).
2. Pull related branches locally.
3. Create a new request
4. Enter text that spans 5+ lines in any field that allows multiline comments
5. Save the form
6. Reload the form and verify that all the lines of the text are visible upon page load

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...